### PR TITLE
Add /merged slash command and review reminder

### DIFF
--- a/.claude/commands/merged.md
+++ b/.claude/commands/merged.md
@@ -1,0 +1,31 @@
+# /merged
+
+Run this after merging a PR on GitHub to sync the local repo.
+
+Takes the PR number as an argument (e.g. `/merged 4`).
+
+## Steps
+
+1. Run `gh pr view $ARGUMENTS --json state,mergedAt,headRefName` and inspect the output.
+   - If `state` is not `MERGED`, stop and report: "PR #$ARGUMENTS is not merged (state: <state>). Sync aborted." Do not proceed.
+   - Capture `headRefName` as the feature branch name.
+
+2. Run `git checkout main`.
+
+3. Run `git pull`.
+
+4. Run `git branch -d <headRefName>`.
+   - If the delete fails for any reason, stop and report the error exactly as git printed it. Do not retry with `-D` unless the user explicitly asks.
+
+5. Run `git status` and confirm the working tree is clean.
+
+6. Report back:
+   - PR number merged
+   - Branch deleted
+   - main is now at `<short SHA>` (obtain via `git rev-parse --short HEAD`)
+
+## Constraints
+
+- Do not push anything.
+- Do not delete the remote branch.
+- If git surfaces an error on `git checkout` (e.g. uncommitted work on the feature branch), report it as-is and stop. Do not wrap it in custom handling.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -37,3 +37,7 @@ State one of:
 - QUESTION -- something needs clarification before a verdict
 
 Never approve a PR that fails Pass 1. A well-written PR that doesn't meet the spec is not done.
+
+After both passes complete, end your output with:
+"PR #N is open. After you merge it on GitHub, run `/merged N` to sync locally."
+Use the actual PR number obtained via `gh pr view --json number`.


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/merged.md`: a post-merge local sync command that verifies merge state, checks out main, pulls, and deletes the feature branch with guard rails against force-delete
- Updates `.claude/commands/review.md`: appends a reminder to run `/merged N` after merging, surfaced at the moment it is most useful

## Test plan

- [ ] Read `merged.md` and confirm all 6 AC steps are represented (verify state, capture branch, checkout, pull, branch -d, report)
- [ ] Confirm `merged.md` does not push or delete remote branch
- [ ] Read `review.md` and confirm reminder line is present after "Never approve a PR that fails Pass 1"
- [ ] Confirm no other files were modified

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)