### PR TITLE
Add Gamepad API input to probe-feel prototype

### DIFF
--- a/docs/known-gotchas.md
+++ b/docs/known-gotchas.md
@@ -1,0 +1,7 @@
+# Known Gotchas
+
+Running memory of things that wasted 30+ minutes. Add to this list as issues are discovered.
+
+## Gamepad API
+
+Gamepad API does not report a connected controller until a button is pressed with the tab focused. Press any button after pairing to wake up `navigator.getGamepads()`.

--- a/prototypes/probe-feel/src/main.ts
+++ b/prototypes/probe-feel/src/main.ts
@@ -14,13 +14,40 @@ const TUNING = {
   RETICLE_SPEED: 400,
 } as const;
 
+const DEADZONE = 0.15;
+
+// Standard W3C gamepad mapping (Axis 0/1 = left stick X/Y).
+// Update this comment once the detection log fires and confirms the controller used.
+const BUTTON = {
+  FIRE: 7,    // RT / R2
+  PROBE: 2,   // X / Square
+  CANCEL: 1,  // B / Circle
+  PAUSE: 9,   // Start / Options
+} as const;
+
+type GameInput = {
+  moveX: number;
+  moveY: number;
+  fire: boolean;
+  probeAction: boolean;
+  cancel: boolean;
+  pause: boolean;
+};
+
 type Keys = Record<string, boolean>;
 
 const keys: Keys = {};
+const justPressed = new Set<string>();
+let lastInputSource: 'keyboard' | 'gamepad' = 'keyboard';
+let gamepadLogged = false;
+const prevButtons: boolean[] = [];
+let prevStickOutside = false;
 
 window.addEventListener('keydown', (e) => {
   if (!keys[e.code]) {
     console.log('keydown', e.code);
+    justPressed.add(e.code);
+    lastInputSource = 'keyboard';
   }
   keys[e.code] = true;
 });
@@ -29,6 +56,64 @@ window.addEventListener('keyup', (e) => {
   keys[e.code] = false;
   console.log('keyup', e.code);
 });
+
+function pollGamepad(): GameInput | null {
+  const gp = navigator.getGamepads()[0];
+  if (!gp) return null;
+
+  if (!gamepadLogged) {
+    console.log('Gamepad connected:', gp.id, '| axes:', gp.axes.length, '| buttons:', gp.buttons.length, '| mapping:', gp.mapping);
+    gamepadLogged = true;
+  }
+
+  const rawX = gp.axes[0] ?? 0;
+  const rawY = gp.axes[1] ?? 0;
+  const stickX = Math.abs(rawX) > DEADZONE ? rawX : 0;
+  const stickY = Math.abs(rawY) > DEADZONE ? rawY : 0;
+  const stickOutside = stickX !== 0 || stickY !== 0;
+
+  if (stickOutside && !prevStickOutside) {
+    lastInputSource = 'gamepad';
+  }
+
+  const actionButtons: [number, 'fire' | 'probeAction' | 'cancel' | 'pause'][] = [
+    [BUTTON.FIRE, 'fire'],
+    [BUTTON.PROBE, 'probeAction'],
+    [BUTTON.CANCEL, 'cancel'],
+    [BUTTON.PAUSE, 'pause'],
+  ];
+
+  const input: GameInput = { moveX: stickX, moveY: stickY, fire: false, probeAction: false, cancel: false, pause: false };
+
+  for (const [index, action] of actionButtons) {
+    const pressed = gp.buttons[index]?.pressed ?? false;
+    const wasPressed = prevButtons[index] ?? false;
+    if (pressed && !wasPressed) {
+      lastInputSource = 'gamepad';
+      input[action] = true;
+    }
+  }
+
+  prevStickOutside = stickOutside;
+  for (let i = 0; i < gp.buttons.length; i++) {
+    prevButtons[i] = gp.buttons[i].pressed;
+  }
+
+  return input;
+}
+
+function getKeyboardInput(): GameInput {
+  const moveX = (keys['ArrowRight'] || keys['KeyD'] ? 1 : 0) - (keys['ArrowLeft'] || keys['KeyA'] ? 1 : 0);
+  const moveY = (keys['ArrowDown'] || keys['KeyS'] ? 1 : 0) - (keys['ArrowUp'] || keys['KeyW'] ? 1 : 0);
+  return {
+    moveX,
+    moveY,
+    fire: justPressed.has('Space'),
+    probeAction: justPressed.has('KeyE'),
+    cancel: justPressed.has('KeyQ'),
+    pause: justPressed.has('Escape'),
+  };
+}
 
 const canvas = document.getElementById('canvas') as HTMLCanvasElement;
 const ctx = canvas.getContext('2d')!;
@@ -39,7 +124,17 @@ function loop(timestamp: number): void {
   const deltaMs = timestamp - lastTime;
   lastTime = timestamp;
 
+  const gpInput = pollGamepad();
+  const input = lastInputSource === 'gamepad' && gpInput !== null
+    ? gpInput
+    : getKeyboardInput();
+
   ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  justPressed.clear();
+
+  void deltaMs;
+  void input;
 
   requestAnimationFrame(loop);
 }


### PR DESCRIPTION
## Summary

- Adds `pollGamepad()` to `prototypes/probe-feel/src/main.ts`: polls `navigator.getGamepads()` each frame, reads left stick (analog, with deadzone) and four action buttons (edge-detected)
- Introduces `GameInput` type as the unified input struct both keyboard and gamepad produce
- Last-input source switches on new input only (button transition or stick crossing deadzone threshold), not on continuous state - no oscillation when holding trigger while tapping keyboard
- Keyboard path unchanged; `justPressed` set added for keyboard edge detection of action buttons
- Creates `docs/known-gotchas.md` with Gamepad API wake-up note

## Button mapping (W3C standard, update code comment after first detection log)

| Action | Index | Xbox | PS |
|--------|-------|------|----|
| Fire | 7 | RT | R2 |
| Probe | 2 | X | Square |
| Cancel | 1 | B | Circle |
| Pause | 9 | Start | Options |

## Test plan

- [ ] `npm run dev` in `prototypes/probe-feel/`, open browser, confirm no console errors
- [ ] Connect controller, press a button - confirm one-time detection log fires with controller name/axes/buttons/mapping
- [ ] Move left stick - confirm `lastInputSource` switches to `'gamepad'` (add a temp log if needed)
- [ ] Hold a face button - confirm action fires only on first frame, not every frame
- [ ] Tap keyboard while holding stick - confirm source switches back to `'keyboard'`
- [ ] Disconnect controller - confirm keyboard still works
- [ ] Confirm `docs/known-gotchas.md` exists with correct entry
- [ ] No files outside `prototypes/probe-feel/src/main.ts` and `docs/known-gotchas.md` modified

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)