### PR TITLE
Update /stop command to target probe-feel prototype port (5199)

### DIFF
--- a/.claude/commands/stop.md
+++ b/.claude/commands/stop.md
@@ -1,6 +1,6 @@
 # /stop local
-Stop whatever is running on port 3000.
+Stop whatever is running on port 5199.
 
 ```bash
-kill -9 $(lsof -t -i:3000) 2>/dev/null && echo "Server stopped" || echo "No server running on port 3000"
+kill -9 $(lsof -t -i:5199) 2>/dev/null && echo "Server stopped" || echo "No server running on port 5199"
 ```


### PR DESCRIPTION
## Summary

- Updates `/stop` description and kill command from port 3000 to port 5199 to match the probe-feel Vite dev server

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)