### PR TITLE
Add player ship and basic shooting to probe-feel prototype

### DIFF
--- a/docs/design-doc.md
+++ b/docs/design-doc.md
@@ -28,6 +28,8 @@ A retrofuturistic vertical shmup where a rebel pilot salvages wrecked alien ship
 
 Gamepad API handles controller input in both browser and Pi kiosk. No native driver work required.
 
+Player vertical movement is clamped to the bottom third of the canvas.
+
 ## 4. Probe mechanic spec
 
 ### Fire sequence

--- a/prototypes/probe-feel/src/main.ts
+++ b/prototypes/probe-feel/src/main.ts
@@ -26,6 +26,7 @@ const BUTTON = {
   PROBE: 2,   // X / Square
   CANCEL: 1,  // B / Circle
   PAUSE: 9,   // Start / Options
+  RESET: 8,   // View (Xbox) / Share (PS) - mirrors keyboard R
 } as const;
 
 type GameInput = {
@@ -35,6 +36,7 @@ type GameInput = {
   probeAction: boolean;
   cancel: boolean;
   pause: boolean;
+  reset: boolean;
 };
 
 type Bullet = { x: number; y: number };
@@ -85,14 +87,15 @@ function pollGamepad(): GameInput | null {
     console.log(`gamepad stick active: moveX=${stickX.toFixed(2)} moveY=${stickY.toFixed(2)}`);
   }
 
-  const actionButtons: [number, 'fire' | 'probeAction' | 'cancel' | 'pause'][] = [
+  const actionButtons: [number, 'fire' | 'probeAction' | 'cancel' | 'pause' | 'reset'][] = [
     [BUTTON.FIRE, 'fire'],
     [BUTTON.PROBE, 'probeAction'],
     [BUTTON.CANCEL, 'cancel'],
     [BUTTON.PAUSE, 'pause'],
+    [BUTTON.RESET, 'reset'],
   ];
 
-  const input: GameInput = { moveX: stickX, moveY: stickY, fire: false, probeAction: false, cancel: false, pause: false };
+  const input: GameInput = { moveX: stickX, moveY: stickY, fire: false, probeAction: false, cancel: false, pause: false, reset: false };
 
   for (const [index, action] of actionButtons) {
     const pressed = gp.buttons[index]?.pressed ?? false;
@@ -122,6 +125,7 @@ function getKeyboardInput(): GameInput {
     probeAction: justPressed.has('KeyE'),
     cancel: justPressed.has('KeyQ'),
     pause: justPressed.has('Escape'),
+    reset: false,
   };
 }
 
@@ -179,7 +183,7 @@ function loop(timestamp: number): void {
     ? gpInput
     : getKeyboardInput();
 
-  if (justPressed.has('KeyR')) {
+  if (justPressed.has('KeyR') || input.reset) {
     state = createState();
   }
 

--- a/prototypes/probe-feel/src/main.ts
+++ b/prototypes/probe-feel/src/main.ts
@@ -7,6 +7,7 @@ const TUNING = {
   COOLDOWN_DESTROYED_MS: 8000,
   PROBE_HP: 3,
   PLAYER_HP: 3,
+  PLAYER_SPEED: 400,
   PLAYER_FIRE_RATE_MS: 200,
   PLAYER_BULLET_SPEED: 500,
   HUSK_FIRE_RATE_MS: 2000,
@@ -15,6 +16,8 @@ const TUNING = {
 } as const;
 
 const DEADZONE = 0.15;
+const PLAYER_W = 32;
+const PLAYER_H = 24;
 
 // Standard W3C gamepad mapping (Axis 0/1 = left stick X/Y).
 // Update this comment once the detection log fires and confirms the controller used.
@@ -34,9 +37,14 @@ type GameInput = {
   pause: boolean;
 };
 
+type Bullet = { x: number; y: number };
+
+type Player = { x: number; y: number; hp: number; lastFireMs: number };
+
 type Keys = Record<string, boolean>;
 
 const keys: Keys = {};
+// Holds edge-detected key presses for one frame; cleared at end of each loop iteration.
 const justPressed = new Set<string>();
 let lastInputSource: 'keyboard' | 'gamepad' = 'keyboard';
 let gamepadLogged = false;
@@ -120,23 +128,85 @@ function getKeyboardInput(): GameInput {
 const canvas = document.getElementById('canvas') as HTMLCanvasElement;
 const ctx = canvas.getContext('2d')!;
 
+// Vertical clamp bounds (y = player center); keeps player in bottom third of canvas.
+const PLAYER_Y_MIN = 420 + PLAYER_H / 2;
+const PLAYER_Y_MAX = canvas.height - PLAYER_H / 2;
+
+function createState() {
+  return {
+    player: {
+      x: canvas.width / 2,
+      y: canvas.height - PLAYER_H / 2 - 20,
+      hp: TUNING.PLAYER_HP,
+      lastFireMs: 0,
+    } as Player,
+    bullets: [] as Bullet[],
+  };
+}
+
+let state = createState();
+
+function drawPlayer(player: Player): void {
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(player.x - PLAYER_W / 2, player.y - PLAYER_H / 2, PLAYER_W, PLAYER_H);
+}
+
+function drawBullets(bullets: Bullet[]): void {
+  ctx.fillStyle = '#ffff00';
+  for (const b of bullets) {
+    ctx.fillRect(b.x - 2, b.y - 5, 4, 10);
+  }
+}
+
+function drawHp(hp: number): void {
+  for (let i = 0; i < TUNING.PLAYER_HP; i++) {
+    ctx.beginPath();
+    ctx.arc(20 + i * 25, 20, 8, 0, Math.PI * 2);
+    ctx.fillStyle = i < hp ? '#ffffff' : '#444444';
+    ctx.fill();
+  }
+}
+
 let lastTime = 0;
 
 function loop(timestamp: number): void {
   const deltaMs = timestamp - lastTime;
   lastTime = timestamp;
+  const deltaSeconds = deltaMs / 1000;
 
   const gpInput = pollGamepad();
   const input = lastInputSource === 'gamepad' && gpInput !== null
     ? gpInput
     : getKeyboardInput();
 
+  if (justPressed.has('KeyR')) {
+    state = createState();
+  }
+
+  state.player.x += input.moveX * TUNING.PLAYER_SPEED * deltaSeconds;
+  state.player.y += input.moveY * TUNING.PLAYER_SPEED * deltaSeconds;
+
+  if (state.player.x < 0) state.player.x = canvas.width;
+  if (state.player.x > canvas.width) state.player.x = 0;
+
+  state.player.y = Math.max(PLAYER_Y_MIN, Math.min(PLAYER_Y_MAX, state.player.y));
+
+  if (input.fire && timestamp - state.player.lastFireMs >= TUNING.PLAYER_FIRE_RATE_MS) {
+    state.bullets.push({ x: state.player.x, y: state.player.y - PLAYER_H / 2 });
+    state.player.lastFireMs = timestamp;
+  }
+
+  for (const b of state.bullets) {
+    b.y -= TUNING.PLAYER_BULLET_SPEED * deltaSeconds;
+  }
+  state.bullets = state.bullets.filter(b => b.y > -5);
+
   ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawPlayer(state.player);
+  drawBullets(state.bullets);
+  drawHp(state.player.hp);
 
   justPressed.clear();
-
-  void deltaMs;
-  void input;
 
   requestAnimationFrame(loop);
 }


### PR DESCRIPTION
## Summary

- Player renders as a white 32x24 rectangle at bottom center of canvas
- WASD / arrow keys / left stick move the player; speed from `TUNING.PLAYER_SPEED` (400 px/s)
- Horizontal wrap; vertical movement clamped to bottom third of canvas (y 420-576, accounting for player height)
- Space / RT fires yellow bullets upward; rate capped by `TUNING.PLAYER_FIRE_RATE_MS`
- Bullets despawn when off the top edge
- Three HP circles rendered top-left; dimmed when HP lost (no damage source until issue #6)
- R key or controller View button (index 8) triggers full state reset via `createState()`; gamepad uses same edge-detection pattern as other buttons
- `PLAYER_SPEED: 400` added to TUNING; `RESET: 8` added to BUTTON map with comment
- Doc comment added to `justPressed` declaration (Set was already implemented in issue #10)
- `design-doc.md` section 3 updated with vertical clamp constraint

## Test plan

- [ ] Player visible as white rectangle at bottom center on load
- [ ] WASD and arrow keys move the player
- [ ] Player exits left, reappears right (and vice versa)
- [ ] Player cannot move above y=420 (top of bottom third)
- [ ] Spacebar fires yellow bullets; holding space does not exceed fire rate cap
- [ ] Bullets travel up and disappear off the top edge
- [ ] Three HP circles visible top-left
- [ ] R key resets player position, HP, and clears bullets
- [ ] Controller View button resets state; holding View does not repeat reset every frame
- [ ] No console errors during normal play

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)