### PR TITLE
feat: establish src/ directory structure and logic/render separation

### DIFF
--- a/src/entities/Bullet.ts
+++ b/src/entities/Bullet.ts
@@ -1,0 +1,1 @@
+export class Bullet {}

--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -1,0 +1,1 @@
+export class Enemy {}

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -1,0 +1,3 @@
+// Phaser render entity only. Reads from logic layer state.
+
+export class Player {}

--- a/src/entities/Probe.ts
+++ b/src/entities/Probe.ts
@@ -1,0 +1,1 @@
+export class Probe {}

--- a/src/entities/Wreck.ts
+++ b/src/entities/Wreck.ts
@@ -1,0 +1,1 @@
+export class Wreck {}

--- a/src/logic/campaign.ts
+++ b/src/logic/campaign.ts
@@ -1,0 +1,4 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+// Campaign state. Tracks chapter, Protocol progress, persistent baseline stats.
+
+export {};

--- a/src/logic/damage.ts
+++ b/src/logic/damage.ts
@@ -1,0 +1,4 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+// Damage calculations. Pure TS, no Phaser.
+
+export {};

--- a/src/logic/intel.ts
+++ b/src/logic/intel.ts
@@ -1,0 +1,4 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+// Intel persistence. Tracks intelUnlocked across runs.
+
+export {};

--- a/src/logic/probe.ts
+++ b/src/logic/probe.ts
@@ -1,0 +1,4 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+// Probe state machine. Pure TS, no Phaser.
+
+export {};

--- a/src/logic/progression-data.ts
+++ b/src/logic/progression-data.ts
@@ -1,0 +1,4 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+// Node definitions. Driven by docs/tuning.md.
+
+export {};

--- a/src/logic/progression.ts
+++ b/src/logic/progression.ts
@@ -1,0 +1,4 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+// Progression tree offer logic. Pure TS, no Phaser.
+
+export {};

--- a/src/logic/rng.ts
+++ b/src/logic/rng.ts
@@ -1,0 +1,4 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+// Seeded RNG module. No Math.random() calls anywhere in logic layer.
+
+export {};

--- a/src/logic/wave-data.ts
+++ b/src/logic/wave-data.ts
@@ -1,0 +1,4 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+// Wave definitions. Driven by docs/tuning.md. Includes runType and spawnDirection fields.
+
+export {};

--- a/src/logic/waves.ts
+++ b/src/logic/waves.ts
@@ -1,0 +1,4 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+// Wave scheduler. Deterministic from seed.
+
+export {};

--- a/src/scenes/GameOverScene.ts
+++ b/src/scenes/GameOverScene.ts
@@ -1,0 +1,7 @@
+import Phaser from 'phaser';
+
+export class GameOverScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'GameOverScene' });
+  }
+}

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1,0 +1,7 @@
+import Phaser from 'phaser';
+
+export class GameScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'GameScene' });
+  }
+}

--- a/src/scenes/MenuScene.ts
+++ b/src/scenes/MenuScene.ts
@@ -1,0 +1,7 @@
+import Phaser from 'phaser';
+
+export class MenuScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'MenuScene' });
+  }
+}

--- a/src/scenes/PauseScene.ts
+++ b/src/scenes/PauseScene.ts
@@ -1,0 +1,7 @@
+import Phaser from 'phaser';
+
+export class PauseScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'PauseScene' });
+  }
+}

--- a/src/systems/audio.ts
+++ b/src/systems/audio.ts
@@ -1,0 +1,3 @@
+// Audio system. Handles slow-mo volume dampening.
+
+export {};

--- a/src/systems/input.ts
+++ b/src/systems/input.ts
@@ -1,0 +1,3 @@
+// Input mapping layer. Keyboard + Gamepad API produce identical logical actions.
+
+export {};

--- a/src/ui/CrewLog.ts
+++ b/src/ui/CrewLog.ts
@@ -1,0 +1,3 @@
+// Crew log dispatch system. ZeroRanger flashing text model.
+
+export class CrewLog {}

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -1,0 +1,3 @@
+// Minimal HUD. HP dots, cooldown ring, flashing text only.
+
+export class HUD {}


### PR DESCRIPTION
## Summary
- Creates 22 stub files across `src/logic/`, `src/scenes/`, `src/entities/`, `src/systems/`, and `src/ui/`
- All logic layer files carry the determinism guard comment and `export {}`; no Phaser imports, no DOM, no `Math.random()`, no `Date.now()`
- Scene stubs are empty `Phaser.Scene` subclasses matching the existing `BootScene.ts` pattern
- Entity stubs use plain `export class Foo {}` -- base class decided at implementation time
- `npm run build` exits 0

Closes #32