### PR TITLE
feat: implement seeded RNG module

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'jest';
+
+export default {
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { useESM: true, tsconfig: 'tsconfig.test.json' }],
+  },
+  testEnvironment: 'node',
+} satisfies Config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^25.6.0",
         "eslint": "^10.2.1",
         "jest": "^30.3.0",
+        "ts-jest": "^29.4.9",
         "typescript": "^6.0.3",
         "vite": "^8.0.10"
       }
@@ -2345,6 +2346,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -3222,6 +3236,28 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4476,6 +4512,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4514,6 +4557,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -4556,6 +4606,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -4614,6 +4674,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5555,6 +5622,85 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.4",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5611,6 +5757,20 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici-types": {
@@ -5824,6 +5984,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "playwright test",
     "lint": "eslint src"
   },
@@ -20,6 +20,7 @@
     "@types/node": "^25.6.0",
     "eslint": "^10.2.1",
     "jest": "^30.3.0",
+    "ts-jest": "^29.4.9",
     "typescript": "^6.0.3",
     "vite": "^8.0.10"
   }

--- a/src/logic/rng.test.ts
+++ b/src/logic/rng.test.ts
@@ -1,0 +1,146 @@
+import { createRng } from './rng';
+
+describe('createRng -- determinism', () => {
+  it('same seed produces identical sequence', () => {
+    const a = createRng(42);
+    const b = createRng(42);
+    for (let i = 0; i < 100; i++) {
+      expect(a.next()).toBe(b.next());
+    }
+  });
+
+  it('different seeds produce different sequences', () => {
+    const a = createRng(1);
+    const b = createRng(2);
+    const results: boolean[] = [];
+    for (let i = 0; i < 20; i++) {
+      results.push(a.next() === b.next());
+    }
+    expect(results.every(Boolean)).toBe(false);
+  });
+});
+
+describe('createRng -- nextInt', () => {
+  it('always returns values within [min, max] inclusive across 10000 calls', () => {
+    const rng = createRng('test-seed');
+    const min = 3;
+    const max = 7;
+    for (let i = 0; i < 10_000; i++) {
+      const v = rng.nextInt(min, max);
+      expect(v).toBeGreaterThanOrEqual(min);
+      expect(v).toBeLessThanOrEqual(max);
+      expect(Number.isInteger(v)).toBe(true);
+    }
+  });
+
+  it('produces all values in range across 10000 calls', () => {
+    const rng = createRng('distribution-seed');
+    const counts: Record<number, number> = { 3: 0, 4: 0, 5: 0, 6: 0, 7: 0 };
+    for (let i = 0; i < 10_000; i++) {
+      counts[rng.nextInt(3, 7)]++;
+    }
+    expect(counts[3]).toBeGreaterThan(0);
+    expect(counts[4]).toBeGreaterThan(0);
+    expect(counts[5]).toBeGreaterThan(0);
+    expect(counts[6]).toBeGreaterThan(0);
+    expect(counts[7]).toBeGreaterThan(0);
+  });
+});
+
+describe('createRng -- nextBool', () => {
+  it('defaults to ~50% true probability', () => {
+    const rng = createRng('bool-seed');
+    let trueCount = 0;
+    for (let i = 0; i < 10_000; i++) {
+      if (rng.nextBool()) trueCount++;
+    }
+    expect(trueCount).toBeGreaterThan(4500);
+    expect(trueCount).toBeLessThan(5500);
+  });
+
+  it('respects custom probability', () => {
+    const rng = createRng('bool-prob-seed');
+    let trueCount = 0;
+    for (let i = 0; i < 10_000; i++) {
+      if (rng.nextBool(0.1)) trueCount++;
+    }
+    expect(trueCount).toBeGreaterThan(500);
+    expect(trueCount).toBeLessThan(1500);
+  });
+});
+
+describe('createRng -- nextItem', () => {
+  it('returns only items from the provided array', () => {
+    const rng = createRng('item-seed');
+    const items = ['a', 'b', 'c'];
+    for (let i = 0; i < 1000; i++) {
+      expect(items).toContain(rng.nextItem(items));
+    }
+  });
+
+  it('returns all items from a large enough sample', () => {
+    const rng = createRng('item-coverage-seed');
+    const items = ['x', 'y', 'z'];
+    const seen = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      seen.add(rng.nextItem(items));
+    }
+    expect(seen.size).toBe(3);
+  });
+});
+
+describe('createRng -- clone', () => {
+  it('clone produces identical sequence from clone point', () => {
+    const rng = createRng('clone-seed');
+    rng.next();
+    rng.next();
+    rng.next();
+    const cloned = rng.clone();
+    for (let i = 0; i < 50; i++) {
+      expect(rng.next()).toBe(cloned.next());
+    }
+  });
+
+  it('clone is independent -- advancing original does not affect clone', () => {
+    const rng = createRng('clone-independence-seed');
+    const cloned = rng.clone();
+    const cloneFirst = cloned.next();
+    rng.next();
+    rng.next();
+    rng.next();
+    const cloneSecond = cloned.next();
+    const fresh = createRng('clone-independence-seed');
+    expect(cloneFirst).toBe(fresh.next());
+    expect(cloneSecond).toBe(fresh.next());
+  });
+});
+
+describe('createRng -- edge cases', () => {
+  it('seed of 0 works and is deterministic', () => {
+    const a = createRng(0);
+    const b = createRng(0);
+    expect(a.next()).toBe(b.next());
+    expect(a.next()).not.toBe(0);
+  });
+
+  it('empty string seed works and is deterministic', () => {
+    const a = createRng('');
+    const b = createRng('');
+    expect(a.next()).toBe(b.next());
+  });
+
+  it('very large seed values work and are deterministic', () => {
+    const seed = Number.MAX_SAFE_INTEGER;
+    const a = createRng(seed);
+    const b = createRng(seed);
+    expect(a.next()).toBe(b.next());
+  });
+
+  it('numeric seed 0 and string seed "0" produce different sequences', () => {
+    const a = createRng(0);
+    const b = createRng('0');
+    const aVals = Array.from({ length: 10 }, () => a.next());
+    const bVals = Array.from({ length: 10 }, () => b.next());
+    expect(aVals).not.toEqual(bVals);
+  });
+});

--- a/src/logic/rng.ts
+++ b/src/logic/rng.ts
@@ -1,4 +1,78 @@
 // NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
 // Seeded RNG module. No Math.random() calls anywhere in logic layer.
+//
+// Algorithm: xorshift128 with four uint32 state values. Period: 2^128 - 1.
+// No external dependencies -- every line is auditable.
+// String seeds are hashed to four uint32 values via djb2 with different salts.
 
-export {};
+export interface Rng {
+  next(): number;
+  nextInt(min: number, max: number): number;
+  nextFloat(min: number, max: number): number;
+  nextBool(probability?: number): boolean;
+  nextItem<T>(array: T[]): T;
+  clone(): Rng;
+}
+
+function djb2(s: string, salt: number): number {
+  let h = (5381 + salt) >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (((h << 5) + h) ^ s.charCodeAt(i)) >>> 0;
+  }
+  return h || 1;
+}
+
+function numberToUint32s(n: number): [number, number, number, number] {
+  const a = n >>> 0;
+  return [
+    (a ^ 0xdeadbeef) >>> 0 || 1,
+    (a ^ 0x41c64e6d) >>> 0 || 2,
+    (a ^ 0x6073) >>> 0 || 3,
+    (a ^ 0x9b1) >>> 0 || 4,
+  ];
+}
+
+function stringToUint32s(s: string): [number, number, number, number] {
+  return [djb2(s, 0), djb2(s, 1), djb2(s, 2), djb2(s, 3)];
+}
+
+function makeRng(x: number, y: number, z: number, w: number): Rng {
+  let _x = x;
+  let _y = y;
+  let _z = z;
+  let _w = w;
+
+  function next(): number {
+    const t = (_x ^ (_x << 11)) >>> 0;
+    _x = _y;
+    _y = _z;
+    _z = _w;
+    _w = (_w ^ (_w >>> 19) ^ (t ^ (t >>> 8))) >>> 0;
+    return _w / 0x100000000;
+  }
+
+  return {
+    next,
+    nextInt(min, max) {
+      return Math.floor(next() * (max - min + 1)) + min;
+    },
+    nextFloat(min, max) {
+      return next() * (max - min) + min;
+    },
+    nextBool(probability = 0.5) {
+      return next() < probability;
+    },
+    nextItem<T>(array: T[]): T {
+      return array[Math.floor(next() * array.length)];
+    },
+    clone() {
+      return makeRng(_x, _y, _z, _w);
+    },
+  };
+}
+
+export function createRng(seed: string | number): Rng {
+  const [x, y, z, w] =
+    typeof seed === 'string' ? stringToUint32s(seed) : numberToUint32s(seed);
+  return makeRng(x, y, z, w);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,6 @@
     "noEmit": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
## Summary
- Implements `src/logic/rng.ts` as a custom xorshift128 seeded PRNG (no external dependencies, every line auditable)
- Exports `createRng(seed)` returning an `Rng` interface with `next`, `nextInt`, `nextFloat`, `nextBool`, `nextItem`, and `clone`
- String seeds hashed via djb2 with four different salts; numeric seeds split into uint32 pairs via mixing
- Configures Jest for ESM + TypeScript via ts-jest (`NODE_OPTIONS=--experimental-vm-modules`)
- Adds `tsconfig.test.json` so `@types/jest` globals are scoped to tests only; excludes `*.test.ts` from the production `tsc --noEmit` check
- 14 Jest tests covering all AC items: determinism, distribution, probability, clone independence, and edge cases (seed 0, empty string, very large values)
- `npm run test` and `npm run build` both exit 0

Closes #34