### PR TITLE
feat: implement input mapping layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,7 @@ MVP = single biome, single boss, clean slate per run, probe mechanic plus 20-nod
 
 ## Known Gotchas
 Running memory of things that wasted 30+ minutes. Add to this list as issues are discovered.
+- Vite generates a .vite/ cache directory on first dev server run. Add to .gitignore immediately after scaffold. (did not waste time at all, other than running a one line fix to add to .gitignore)
 
 - (populate as we go)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,32 @@
         "@types/node": "^25.6.0",
         "eslint": "^10.2.1",
         "jest": "^30.3.0",
+        "jest-environment-jsdom": "^30.3.0",
         "ts-jest": "^29.4.9",
         "typescript": "^6.0.3",
         "vite": "^8.0.10"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -517,6 +539,121 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -914,6 +1051,34 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+      "integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jest/expect": {
@@ -1714,6 +1879,18 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1735,6 +1912,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2076,6 +2260,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2612,6 +2806,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2629,6 +2851,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -2715,6 +2944,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -3269,12 +3511,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3284,6 +3567,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3394,6 +3690,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -3717,6 +4020,29 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+      "integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/environment-jsdom-abstract": "30.3.0",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-environment-node": {
@@ -4126,6 +4452,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4721,6 +5087,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4831,6 +5204,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -5210,6 +5596,33 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5514,6 +5927,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -5615,12 +6035,58 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/ts-jest": {
       "version": "29.4.9",
@@ -5949,6 +6415,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -5957,6 +6436,54 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -6107,6 +6634,45 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/node": "^25.6.0",
     "eslint": "^10.2.1",
     "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.3.0",
     "ts-jest": "^29.4.9",
     "typescript": "^6.0.3",
     "vite": "^8.0.10"

--- a/src/systems/input.test.ts
+++ b/src/systems/input.test.ts
@@ -1,0 +1,218 @@
+/**
+ * @jest-environment jsdom
+ */
+import { createInputManager, LogicalAction } from './input';
+
+function makeGamepad(overrides: Partial<{
+  axes: number[];
+  buttons: { pressed: boolean; value: number }[];
+  id: string;
+  mapping: string;
+}> = {}): Gamepad {
+  return {
+    axes: [0, 0, 0, 0],
+    buttons: Array.from({ length: 17 }, () => ({ pressed: false, value: 0, touched: false })),
+    connected: true,
+    id: 'Mock Gamepad',
+    index: 0,
+    mapping: 'standard',
+    timestamp: 0,
+    hapticActuators: [],
+    vibrationActuator: null,
+    ...overrides,
+  } as unknown as Gamepad;
+}
+
+function mockGamepads(gamepad: Gamepad | null) {
+  Object.defineProperty(navigator, 'getGamepads', {
+    value: () => [gamepad],
+    writable: true,
+    configurable: true,
+  });
+}
+
+function pressKey(key: string) {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+function releaseKey(key: string) {
+  window.dispatchEvent(new KeyboardEvent('keyup', { key, bubbles: true }));
+}
+
+describe('input -- justPressed edge detection', () => {
+  it('PROBE appears in justPressed on the frame E is pressed', () => {
+    mockGamepads(null);
+    const mgr = createInputManager();
+    pressKey('e');
+    const frame = mgr.update();
+    expect(frame.justPressed.has(LogicalAction.PROBE)).toBe(true);
+    mgr.dispose();
+  });
+
+  it('PROBE is not in justPressed on subsequent frames without a new keydown', () => {
+    mockGamepads(null);
+    const mgr = createInputManager();
+    pressKey('e');
+    mgr.update();
+    const frame = mgr.update();
+    expect(frame.justPressed.has(LogicalAction.PROBE)).toBe(false);
+    mgr.dispose();
+  });
+
+  it('FIRE appears in justPressed on Space press', () => {
+    mockGamepads(null);
+    const mgr = createInputManager();
+    pressKey(' ');
+    const frame = mgr.update();
+    expect(frame.justPressed.has(LogicalAction.FIRE)).toBe(true);
+    mgr.dispose();
+  });
+
+  it('PAUSE appears in justPressed on Escape press', () => {
+    mockGamepads(null);
+    const mgr = createInputManager();
+    pressKey('Escape');
+    const frame = mgr.update();
+    expect(frame.justPressed.has(LogicalAction.PAUSE)).toBe(true);
+    mgr.dispose();
+  });
+
+  it('CANCEL_PROBE appears in justPressed on Q press', () => {
+    mockGamepads(null);
+    const mgr = createInputManager();
+    pressKey('q');
+    const frame = mgr.update();
+    expect(frame.justPressed.has(LogicalAction.CANCEL_PROBE)).toBe(true);
+    mgr.dispose();
+  });
+});
+
+describe('input -- diagonal normalization', () => {
+  it('W+D combined magnitude is 1.0', () => {
+    mockGamepads(null);
+    const mgr = createInputManager();
+    pressKey('w');
+    pressKey('d');
+    const { current } = mgr.update();
+    const magnitude = Math.sqrt(current.moveX ** 2 + current.moveY ** 2);
+    expect(magnitude).toBeCloseTo(1.0, 5);
+    mgr.dispose();
+  });
+
+  it('single direction magnitude is 1.0', () => {
+    mockGamepads(null);
+    const mgr = createInputManager();
+    pressKey('w');
+    const { current } = mgr.update();
+    const magnitude = Math.sqrt(current.moveX ** 2 + current.moveY ** 2);
+    expect(magnitude).toBeCloseTo(1.0, 5);
+    mgr.dispose();
+  });
+
+  it('no keys pressed produces magnitude 0', () => {
+    mockGamepads(null);
+    const mgr = createInputManager();
+    const { current } = mgr.update();
+    expect(current.moveX).toBe(0);
+    expect(current.moveY).toBe(0);
+    mgr.dispose();
+  });
+});
+
+describe('input -- gamepad deadzone', () => {
+  it('axis below deadzone (0.1) produces moveX of 0', () => {
+    mockGamepads(makeGamepad({ axes: [0.1, 0, 0, 0] }));
+    const mgr = createInputManager();
+    // Trigger gamepad source by pressing a gamepad button first
+    const gp = makeGamepad({
+      axes: [0.1, 0, 0, 0],
+      buttons: Array.from({ length: 17 }, (_, i) =>
+        i === 7 ? { pressed: true, value: 1, touched: false } : { pressed: false, value: 0, touched: false }
+      ),
+    });
+    mockGamepads(gp);
+    mgr.update(); // first frame: button 7 pressed, source switches to gamepad
+    // Now test with stick only (button released, stick below deadzone)
+    mockGamepads(makeGamepad({ axes: [0.1, 0, 0, 0] }));
+    const { current } = mgr.update();
+    expect(current.moveX).toBe(0);
+    mgr.dispose();
+  });
+
+  it('axis above deadzone (0.5) passes through', () => {
+    // Press button first to switch to gamepad source
+    const gpWithButton = makeGamepad({
+      axes: [0.5, 0, 0, 0],
+      buttons: Array.from({ length: 17 }, (_, i) =>
+        i === 7 ? { pressed: true, value: 1, touched: false } : { pressed: false, value: 0, touched: false }
+      ),
+    });
+    mockGamepads(gpWithButton);
+    const mgr = createInputManager();
+    mgr.update(); // switches to gamepad
+    mockGamepads(makeGamepad({ axes: [0.5, 0, 0, 0] }));
+    const { current } = mgr.update();
+    expect(current.moveX).toBeCloseTo(0.5, 5);
+    mgr.dispose();
+  });
+});
+
+describe('input -- last-input-wins source switching', () => {
+  it('keydown switches source to keyboard, overriding gamepad values', () => {
+    const gp = makeGamepad({
+      axes: [1.0, 0, 0, 0],
+      buttons: Array.from({ length: 17 }, (_, i) =>
+        i === 7 ? { pressed: true, value: 1, touched: false } : { pressed: false, value: 0, touched: false }
+      ),
+    });
+    mockGamepads(gp);
+    const mgr = createInputManager();
+    mgr.update(); // gamepad source, moveX = 1.0
+
+    // Keyboard event switches source back to keyboard; no keys held so moveX = 0
+    mockGamepads(makeGamepad({ axes: [1.0, 0, 0, 0] }));
+    pressKey('a'); // keydown triggers keyboard source
+    const { current } = mgr.update();
+    // keyboard source: A = moveX -1, gamepad axes[0]=1.0 ignored
+    expect(current.moveX).toBe(-1);
+    mgr.dispose();
+  });
+
+  it('gamepad button press switches source to gamepad', () => {
+    mockGamepads(null);
+    const mgr = createInputManager();
+    pressKey('d');
+    mgr.update(); // keyboard source, moveX = 1
+
+    releaseKey('d');
+    const gp = makeGamepad({
+      axes: [0, 0, 0, 0],
+      buttons: Array.from({ length: 17 }, (_, i) =>
+        i === 7 ? { pressed: true, value: 1, touched: false } : { pressed: false, value: 0, touched: false }
+      ),
+    });
+    mockGamepads(gp);
+    const { current } = mgr.update(); // gamepad source: fire=true
+    expect(current.fire).toBe(true);
+    mgr.dispose();
+  });
+
+  it('gamepad disconnect falls back to keyboard', () => {
+    const gp = makeGamepad({
+      buttons: Array.from({ length: 17 }, (_, i) =>
+        i === 7 ? { pressed: true, value: 1, touched: false } : { pressed: false, value: 0, touched: false }
+      ),
+    });
+    mockGamepads(gp);
+    const mgr = createInputManager();
+    mgr.update(); // gamepad source
+
+    // Simulate disconnect
+    window.dispatchEvent(new Event('gamepaddisconnected'));
+    mockGamepads(null);
+    pressKey('e');
+    const { current } = mgr.update();
+    expect(current.probe).toBe(true); // keyboard source after disconnect
+    mgr.dispose();
+  });
+});

--- a/src/systems/input.ts
+++ b/src/systems/input.ts
@@ -1,3 +1,183 @@
 // Input mapping layer. Keyboard + Gamepad API produce identical logical actions.
 
-export {};
+export enum LogicalAction {
+  MOVE_X,
+  MOVE_Y,
+  FIRE,
+  PROBE,
+  CANCEL_PROBE,
+  PAUSE,
+  DASH,
+}
+
+export interface InputState {
+  moveX: number;
+  moveY: number;
+  fire: boolean;
+  probe: boolean;
+  cancelProbe: boolean;
+  pause: boolean;
+  dash: boolean;
+}
+
+export interface InputFrame {
+  current: InputState;
+  previous: InputState;
+  justPressed: Set<LogicalAction>;
+}
+
+export interface InputManager {
+  update(): InputFrame;
+  dispose(): void;
+}
+
+const DEADZONE = 0.15;
+
+const IDLE_STATE: InputState = {
+  moveX: 0,
+  moveY: 0,
+  fire: false,
+  probe: false,
+  cancelProbe: false,
+  pause: false,
+  dash: false,
+};
+
+function applyDeadzone(value: number): number {
+  return Math.abs(value) > DEADZONE ? value : 0;
+}
+
+function normalize(x: number, y: number): [number, number] {
+  const mag = Math.sqrt(x * x + y * y);
+  return mag > 1 ? [x / mag, y / mag] : [x, y];
+}
+
+function computeJustPressed(prev: InputState, curr: InputState): Set<LogicalAction> {
+  const set = new Set<LogicalAction>();
+  if (!prev.fire && curr.fire) set.add(LogicalAction.FIRE);
+  if (!prev.probe && curr.probe) set.add(LogicalAction.PROBE);
+  if (!prev.cancelProbe && curr.cancelProbe) set.add(LogicalAction.CANCEL_PROBE);
+  if (!prev.pause && curr.pause) set.add(LogicalAction.PAUSE);
+  if (prev.moveX === 0 && curr.moveX !== 0) set.add(LogicalAction.MOVE_X);
+  if (prev.moveY === 0 && curr.moveY !== 0) set.add(LogicalAction.MOVE_Y);
+  return set;
+}
+
+function stateFromKeyboard(heldKeys: Set<string>): InputState {
+  let moveX = 0;
+  let moveY = 0;
+  if (heldKeys.has('a') || heldKeys.has('A') || heldKeys.has('ArrowLeft')) moveX -= 1;
+  if (heldKeys.has('d') || heldKeys.has('D') || heldKeys.has('ArrowRight')) moveX += 1;
+  if (heldKeys.has('w') || heldKeys.has('W') || heldKeys.has('ArrowUp')) moveY -= 1;
+  if (heldKeys.has('s') || heldKeys.has('S') || heldKeys.has('ArrowDown')) moveY += 1;
+  moveX = Math.max(-1, Math.min(1, moveX));
+  moveY = Math.max(-1, Math.min(1, moveY));
+  const [nx, ny] = normalize(moveX, moveY);
+  return {
+    moveX: nx,
+    moveY: ny,
+    fire: heldKeys.has(' ') || heldKeys.has('j') || heldKeys.has('J'),
+    probe: heldKeys.has('e') || heldKeys.has('E'),
+    cancelProbe: heldKeys.has('q') || heldKeys.has('Q'),
+    pause: heldKeys.has('Escape'),
+    dash: false,
+  };
+}
+
+function stateFromGamepad(gp: Gamepad): InputState {
+  const rawX = applyDeadzone(gp.axes[0] ?? 0);
+  const rawY = applyDeadzone(gp.axes[1] ?? 0);
+  const [moveX, moveY] = normalize(rawX, rawY);
+  return {
+    moveX,
+    moveY,
+    fire: gp.buttons[7]?.pressed ?? false,
+    probe: gp.buttons[2]?.pressed ?? false,
+    cancelProbe: gp.buttons[1]?.pressed ?? false,
+    pause: gp.buttons[9]?.pressed ?? false,
+    dash: false,
+  };
+}
+
+export function createInputManager(): InputManager {
+  const heldKeys = new Set<string>();
+  let prevState: InputState = { ...IDLE_STATE };
+  let activeSource: 'keyboard' | 'gamepad' = 'keyboard';
+  let hadKeydownThisFrame = false;
+  let prevGamepadButtons: boolean[] = [];
+  let prevRawAxes: [number, number] = [0, 0];
+  let gamepadLoggedOnce = false;
+
+  function onKeyDown(e: KeyboardEvent): void {
+    heldKeys.add(e.key);
+    hadKeydownThisFrame = true;
+  }
+
+  function onKeyUp(e: KeyboardEvent): void {
+    heldKeys.delete(e.key);
+  }
+
+  function onGamepadConnected(e: Event): void {
+    if (!gamepadLoggedOnce) {
+      const gp = (e as GamepadEvent).gamepad;
+      console.log(`Gamepad connected: ${gp.id} (mapping: ${gp.mapping})`);
+      gamepadLoggedOnce = true;
+    }
+  }
+
+  function onGamepadDisconnected(): void {
+    if (activeSource === 'gamepad') {
+      activeSource = 'keyboard';
+    }
+  }
+
+  window.addEventListener('keydown', onKeyDown);
+  window.addEventListener('keyup', onKeyUp);
+  window.addEventListener('gamepadconnected', onGamepadConnected);
+  window.addEventListener('gamepaddisconnected', onGamepadDisconnected);
+
+  function update(): InputFrame {
+    const gamepads = navigator.getGamepads();
+    const gp = gamepads[0] ?? null;
+
+    // Keyboard wins on same-frame ties -- hadKeydownThisFrame checked first
+    if (hadKeydownThisFrame) {
+      activeSource = 'keyboard';
+    } else if (gp) {
+      const rawX = gp.axes[0] ?? 0;
+      const rawY = gp.axes[1] ?? 0;
+      const newButtonPress = gp.buttons.some(
+        (btn, i) => btn.pressed && !(prevGamepadButtons[i] ?? false)
+      );
+      const stickCrossed =
+        (Math.abs(prevRawAxes[0]) <= DEADZONE && Math.abs(rawX) > DEADZONE) ||
+        (Math.abs(prevRawAxes[1]) <= DEADZONE && Math.abs(rawY) > DEADZONE);
+      if (newButtonPress || stickCrossed) activeSource = 'gamepad';
+      prevRawAxes = [rawX, rawY];
+    }
+
+    hadKeydownThisFrame = false;
+
+    const current =
+      activeSource === 'gamepad' && gp
+        ? stateFromGamepad(gp)
+        : stateFromKeyboard(heldKeys);
+
+    prevGamepadButtons = gp ? gp.buttons.map((b) => b.pressed) : [];
+
+    const justPressed = computeJustPressed(prevState, current);
+    const previous = prevState;
+    prevState = current;
+
+    return { current, previous, justPressed };
+  }
+
+  function dispose(): void {
+    window.removeEventListener('keydown', onKeyDown);
+    window.removeEventListener('keyup', onKeyUp);
+    window.removeEventListener('gamepadconnected', onGamepadConnected);
+    window.removeEventListener('gamepaddisconnected', onGamepadDisconnected);
+  }
+
+  return { update, dispose };
+}


### PR DESCRIPTION
## Summary
- Implements `src/systems/input.ts` as the single input source of truth: `LogicalAction` enum, `InputState`, `InputFrame`, `InputManager` types, and `createInputManager()`
- Keyboard: WASD/arrows for movement, Space/J for fire, E for probe, Q for cancel, Escape for pause; all binary (-1/0/1)
- Gamepad: left stick for movement (analog, 0.15 deadzone), W3C standard button mapping (RT=fire, X=probe, B=cancel, Menu=pause); one-time `console.log` on first connection
- Last-input-wins source switching: keyboard wins on same-frame ties; gamepad source triggered by button press edge or stick crossing deadzone from inside; falls back to keyboard on disconnect
- Diagonal normalization clamps combined magnitude to 1.0
- `DASH` is in `LogicalAction` per spec; `InputState.dash` is always `false` from this layer -- context resolution happens in the logic layer
- 13 jsdom Jest tests (per-file `@jest-environment jsdom` pragma) covering justPressed edge detection, diagonal normalization, deadzone filtering, and last-input-wins switching
- `jest-environment-jsdom@^30.3.0` added as devDependency
- `npm run test` (27/27) and `npm run build` both exit 0

Closes #36