### PR TITLE
feat: implement game loop and scene shell

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,9 @@
 import Phaser from 'phaser';
 import { BootScene } from './scenes/BootScene';
+import { MenuScene } from './scenes/MenuScene';
+import { GameScene } from './scenes/GameScene';
+import { PauseScene } from './scenes/PauseScene';
+import { GameOverScene } from './scenes/GameOverScene';
 
 new Phaser.Game({
   width: 1280,
@@ -7,7 +11,7 @@ new Phaser.Game({
   type: Phaser.AUTO,
   backgroundColor: '#000000',
   parent: 'game-container',
-  scene: [BootScene],
+  scene: [BootScene, MenuScene, GameScene, PauseScene, GameOverScene],
   scale: {
     mode: Phaser.Scale.FIT,
     autoCenter: Phaser.Scale.CENTER_BOTH,

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -6,6 +6,6 @@ export class BootScene extends Phaser.Scene {
   }
 
   create(): void {
-    console.log('BootScene started');
+    this.scene.start('MenuScene');
   }
 }

--- a/src/scenes/GameOverScene.ts
+++ b/src/scenes/GameOverScene.ts
@@ -4,4 +4,19 @@ export class GameOverScene extends Phaser.Scene {
   constructor() {
     super({ key: 'GameOverScene' });
   }
+
+  create(): void {
+    this.add.text(640, 300, 'PROTOCOL TERMINATED', {
+      fontSize: '48px',
+      color: '#ffffff',
+    }).setOrigin(0.5);
+
+    this.add.text(640, 380, 'Press any key to restart', {
+      fontSize: '20px',
+      color: '#aaaaaa',
+    }).setOrigin(0.5);
+
+    // keyboard plugin always available in browser environment
+    this.input.keyboard!.once('keydown', () => this.scene.start('MenuScene'));
+  }
 }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1,7 +1,47 @@
 import Phaser from 'phaser';
+import { createInputManager, InputManager, InputFrame } from '../systems/input';
+
+const SLOWMO_FACTOR = 0.2;
 
 export class GameScene extends Phaser.Scene {
+  private inputManager!: InputManager;
+  private inSlowMo = false;
+  private loggedUpdateLogic = false;
+  private loggedDrawScene = false;
+
   constructor() {
     super({ key: 'GameScene' });
+  }
+
+  create(): void {
+    this.inputManager = createInputManager();
+    this.events.once('shutdown', () => this.inputManager.dispose());
+  }
+
+  update(time: number, delta: number): void {
+    const inputFrame = this.inputManager.update();
+    const effectiveDeltaMs = delta * (this.inSlowMo ? SLOWMO_FACTOR : 1);
+    const effectiveDeltaSeconds = effectiveDeltaMs / 1000;
+    this.updateLogic(inputFrame, effectiveDeltaMs, time);
+    this.drawScene();
+    void effectiveDeltaSeconds;
+  }
+
+  setSlowMo(active: boolean): void {
+    this.inSlowMo = active;
+  }
+
+  private updateLogic(_inputFrame: InputFrame, _effectiveDeltaMs: number, _timestamp: number): void {
+    if (!this.loggedUpdateLogic) {
+      console.log('updateLogic stub');
+      this.loggedUpdateLogic = true;
+    }
+  }
+
+  private drawScene(): void {
+    if (!this.loggedDrawScene) {
+      console.log('drawScene stub');
+      this.loggedDrawScene = true;
+    }
   }
 }

--- a/src/scenes/MenuScene.ts
+++ b/src/scenes/MenuScene.ts
@@ -1,7 +1,42 @@
 import Phaser from 'phaser';
 
 export class MenuScene extends Phaser.Scene {
+  private transitioning = false;
+
   constructor() {
     super({ key: 'MenuScene' });
+  }
+
+  create(): void {
+    this.transitioning = false;
+
+    this.add.text(640, 300, 'SCAVENGER PROTOCOL', {
+      fontSize: '48px',
+      color: '#ffffff',
+    }).setOrigin(0.5);
+
+    this.add.text(640, 380, 'Press any key to begin Protocol', {
+      fontSize: '20px',
+      color: '#aaaaaa',
+    }).setOrigin(0.5);
+
+    // keyboard plugin always available in browser environment
+    this.input.keyboard!.once('keydown', () => this.startGame());
+  }
+
+  update(): void {
+    if (this.transitioning) return;
+    const gamepads = navigator.getGamepads();
+    for (const gp of gamepads) {
+      if (gp && gp.buttons.some((b) => b.pressed)) {
+        this.startGame();
+        return;
+      }
+    }
+  }
+
+  private startGame(): void {
+    this.transitioning = true;
+    this.scene.start('GameScene');
   }
 }

--- a/src/scenes/PauseScene.ts
+++ b/src/scenes/PauseScene.ts
@@ -4,4 +4,9 @@ export class PauseScene extends Phaser.Scene {
   constructor() {
     super({ key: 'PauseScene' });
   }
+
+  create(): void {
+    // keyboard plugin always available in browser environment
+    this.input.keyboard!.once('keydown-ESC', () => this.scene.start('GameScene'));
+  }
 }


### PR DESCRIPTION
## Summary
- `BootScene`: immediately transitions to `MenuScene` (no asset loading)
- `MenuScene`: "SCAVENGER PROTOCOL" and "Press any key to begin Protocol" centered on 1280x720 canvas; keyboard or gamepad button transitions to `GameScene`; `transitioning` guard prevents double-start
- `GameScene`: creates `InputManager` on scene start, disposes on shutdown; `update()` calls `inputManager.update()`, computes `effectiveDeltaMs` and `effectiveDeltaSeconds` via `SLOWMO_FACTOR = 0.2`; `setSlowMo(active)` toggles slow-mo; `updateLogic` and `drawScene` stubs log once then go silent
- `PauseScene`: Escape transitions back to `GameScene`
- `GameOverScene`: "PROTOCOL TERMINATED" and "Press any key to restart"; any key transitions to `MenuScene`
- `src/main.ts`: all five scenes registered
- All `this.input.keyboard!` assertions accompanied by comment explaining the non-null is safe in a browser environment
- `npm run build` exits 0; 27/27 tests pass
- Browser verification required: black canvas with `MenuScene` text visible (cannot be automated without Playwright smoke test, which is future work)

Closes #38