### PR TITLE
chore: update /review and /test slash commands for Vite workflow

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -38,6 +38,15 @@ State one of:
 
 Never approve a PR that fails Pass 1. A well-written PR that doesn't meet the spec is not done.
 
-After both passes complete, end your output with:
+After both passes complete, end your output with one of:
+
+If APPROVED:
+"## Manual verification
+[List the specific browser checks for this PR, derived from the PR description and AC]
+
+Run `/test [N]` to start the dev server for manual verification. PR #N is open. After you verify and merge on GitHub, run `/merged N` to sync locally."
+
+If CHANGES REQUESTED or QUESTION:
 "PR #N is open. After you merge it on GitHub, run `/merged N` to sync locally."
+
 Use the actual PR number obtained via `gh pr view --json number`.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,12 +1,15 @@
 # /test
-Switch to the branch for a given PR number and start the server for manual testing.
+Switch to a PR branch and start the Vite dev server for manual testing. Run this after /review returns APPROVED.
 
 Usage: /test #[PR number]
 
 Steps:
 1. Run: gh pr view [PR number] --json headRefName --jq '.headRefName' to get the branch name
 2. Run: git checkout [branch name]
-3. Kill any existing process on port 3000: kill -9 $(lsof -t -i:3000) 2>/dev/null
-4. Run: node server.js
+3. Kill any existing process on port 5173: kill -9 $(lsof -t -i:5173) 2>/dev/null
+4. Run: npm run dev from the project root
+5. Report: active branch name and dev server URL (http://localhost:5173 unless Vite picks a different port, in which case report the actual port)
+6. Read the PR description and linked issue AC. List the specific things Paul should verify manually in the browser for this PR. Be concrete: not "verify the game works" but "confirm the MenuScene displays SCAVENGER PROTOCOL centered on a black canvas" or "confirm pressing E fires the probe and the game enters slow-mo."
+7. Wait for Paul to confirm manual verification is complete before he merges.
 
-After starting, confirm which branch is active and the server URL.
+Note: /test is for post-review manual verification only. Always run /review first. Never run /test on a PR that has not received an APPROVED verdict from /review.


### PR DESCRIPTION
## Summary
- `/review`: conditional ending -- APPROVED verdict now ends with a "Manual verification" section listing PR-specific browser checks, followed by a prompt to run `/test [N]`; CHANGES REQUESTED and QUESTION verdicts keep the existing plain ending
- `/test`: full replacement -- port 3000 + `node server.js` updated to port 5173 + `npm run dev`; adds steps to list concrete browser verification items from the PR description and AC, and to wait for confirmation before merge
- Exactly 2 files changed; `npm run build` exits 0

Closes #40