### PR TITLE
fix: convert jest.config.ts to jest.config.js

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,3 @@
-import type { Config } from 'jest';
-
 export default {
   extensionsToTreatAsEsm: ['.ts'],
   transform: {
@@ -15,4 +13,4 @@ export default {
       functions: 80,
     },
   },
-} satisfies Config;
+};


### PR DESCRIPTION
## Summary

Closes #44

## What changed

- `jest.config.ts` renamed to `jest.config.js`
- Removed `import type { Config } from 'jest'` and `satisfies Config` -- the only TypeScript-specific constructs in the file
- Content is otherwise identical

## Test plan

- [x] `npm run test -- --coverage` passes (27 tests, coverage above threshold)
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [ ] CI `unit` job passes on this PR
- [ ] Manual verification complete (run `/test [N]`)