### PR TITLE
docs: update tuning.md with Probe and Salvage branch redesigns

### DIFF
--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -125,7 +125,7 @@ All prototype values felt right after 20+ runs. Locked in.
 | Pool | Nodes |
 |---|---|
 | Common (Tier 1 tether, 0-1.5s) | Pellet Drive, Plating, Reinforced Tether, Thruster Boost, Scrap Sense |
-| Uncommon (Tier 2 tether, 1.5-3s) | Twin Shot, Hull Memory, Quick Recall, Slip Drive, Extended Haul, Piercing Rounds, Static Shielding, Integrity Survey, Weightless |
+| Uncommon (Tier 2 tether, 1.5-3s) | Twin Shot, Hull Memory, Quick Recall, Slip Drive, Extended Haul, Piercing Rounds, Static Shielding, Infiltration, Integrity Survey, Weightless |
 | Rare (Tier 3 tether, 3s+) | Salvo, Phoenix Protocol, Salvager's Kiss, Phase Shift, Deep Salvage |
 
 ### Full node table


### PR DESCRIPTION
## Summary

Closes #49

## What changed

Single line change: added `Infiltration` to the Uncommon rarity pool assignment table in `docs/tuning.md`.

All other AC items from #49 were already present in the document from the design session (node table entries for Infiltration and Integrity Survey, updated Salvager's Kiss description, cross-branch synergy entry, Wide Scanner and Opportunist removed).

## Test plan

- [x] Documentation only -- no logic, no tests, no build impact
- [x] Uncommon pool now lists all 10 expected nodes (5 branches x 2 tiers)