### PR TITLE
feat: implement player ship - movement, inertia, wrap, and shooting

### DIFF
--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -22,7 +22,7 @@ Single forward shot. Maximum design space for progression to add multishot, spre
 | Hitbox size | 16 x 16 px | Smaller than 48 x 48 visible sprite. Touhou-style core hitbox. |
 | Max move speed | 320 px/s | Slower than prototype's 400 because inertia plus analog stick reduces overshoot need. |
 | Acceleration | 1600 px/s² | Reaches max speed in ~0.2s from standstill. |
-| Deceleration | 2400 px/s² | Stops faster than starts. Decisive stops. |
+| Deceleration | 800 px/s² | A bit drifty. On first test after scaffolding, changed from 2400 to 800. Will likely tune more.|
 | Y movement bound | bottom 35% of canvas | More room than prototype's 30%, allowing upward dodge into bullet patterns. |
 | Bullet damage | 10 | Round number for clean progression scaling. |
 | Fire rate | 200 ms (5 shots/sec) | Same as prototype, felt right. |

--- a/src/logic/player.test.ts
+++ b/src/logic/player.test.ts
@@ -1,0 +1,121 @@
+import { createPlayer, updatePlayer, PlayerState } from './player';
+import type { InputState } from '../systems/input';
+
+const IDLE: InputState = {
+  moveX: 0, moveY: 0, fire: false, probe: false, cancelProbe: false, pause: false, dash: false,
+};
+
+function withInput(overrides: Partial<InputState>): InputState {
+  return { ...IDLE, ...overrides };
+}
+
+function stepMany(state: PlayerState, input: InputState, steps: number, deltaMs = 16): PlayerState {
+  let s = state;
+  for (let i = 0; i < steps; i++) {
+    s = updatePlayer(s, input, deltaMs, i * deltaMs);
+  }
+  return s;
+}
+
+describe('createPlayer', () => {
+  it('returns correct initial state', () => {
+    const p = createPlayer();
+    expect(p.x).toBe(640);
+    expect(p.y).toBe(630);
+    expect(p.vx).toBe(0);
+    expect(p.vy).toBe(0);
+    expect(p.hp).toBe(3);
+    expect(p.lastFireMs).toBe(Number.NEGATIVE_INFINITY);
+    expect(p.bullets).toHaveLength(0);
+  });
+});
+
+describe('movement', () => {
+  it('accelerates toward max speed when input held', () => {
+    const start = createPlayer();
+    const after = stepMany(start, withInput({ moveX: 1 }), 5);
+    expect(after.vx).toBeGreaterThan(0);
+    expect(after.vx).toBeLessThanOrEqual(320);
+  });
+
+  it('caps velocity at PLAYER_SPEED', () => {
+    const start = createPlayer();
+    const after = stepMany(start, withInput({ moveX: 1 }), 200);
+    expect(after.vx).toBeCloseTo(320, 0);
+  });
+
+  it('decelerates to zero when input released', () => {
+    let state = stepMany(createPlayer(), withInput({ moveX: 1 }), 200);
+    expect(state.vx).toBeGreaterThan(0);
+    state = stepMany(state, IDLE, 200);
+    expect(state.vx).toBe(0);
+  });
+
+  it('diagonal input produces combined speed approximately equal to PLAYER_SPEED at steady state', () => {
+    const state = stepMany(createPlayer(), withInput({ moveX: 1, moveY: 1 }), 500);
+    const speed = Math.sqrt(state.vx ** 2 + state.vy ** 2);
+    expect(speed).toBeCloseTo(320, 0);
+  });
+});
+
+describe('position bounds', () => {
+  it('wraps x to CANVAS_WIDTH when x < 0', () => {
+    const state: PlayerState = { ...createPlayer(), x: -1, vx: -1 };
+    const after = updatePlayer(state, IDLE, 16, 0);
+    expect(after.x).toBe(1280);
+  });
+
+  it('wraps x to 0 when x > CANVAS_WIDTH', () => {
+    const state: PlayerState = { ...createPlayer(), x: 1281, vx: 1 };
+    const after = updatePlayer(state, IDLE, 16, 0);
+    expect(after.x).toBe(0);
+  });
+
+  it('clamps y to Y_MIN (432)', () => {
+    const state: PlayerState = { ...createPlayer(), y: 432, vy: -1000 };
+    const after = updatePlayer(state, IDLE, 100, 0);
+    expect(after.y).toBeGreaterThanOrEqual(432);
+  });
+
+  it('clamps y to Y_MAX (684)', () => {
+    const state: PlayerState = { ...createPlayer(), y: 684, vy: 1000 };
+    const after = updatePlayer(state, IDLE, 100, 0);
+    expect(after.y).toBeLessThanOrEqual(684);
+  });
+});
+
+describe('shooting', () => {
+  it('fires a bullet when fire is held', () => {
+    const state = updatePlayer(createPlayer(), withInput({ fire: true }), 16, 300);
+    expect(state.bullets).toHaveLength(1);
+  });
+
+  it('does not fire faster than 200ms interval', () => {
+    // fire at t=0 and t=199 -- only one bullet
+    let state = updatePlayer(createPlayer(), withInput({ fire: true }), 16, 0);
+    state = updatePlayer(state, withInput({ fire: true }), 16, 199);
+    expect(state.bullets).toHaveLength(1);
+  });
+
+  it('fires a second bullet after 200ms has elapsed', () => {
+    let state = updatePlayer(createPlayer(), withInput({ fire: true }), 16, 0);
+    state = updatePlayer(state, withInput({ fire: true }), 16, 200);
+    expect(state.bullets).toHaveLength(2);
+  });
+
+  it('bullets move upward each frame', () => {
+    let state = updatePlayer(createPlayer(), withInput({ fire: true }), 16, 0);
+    const startY = state.bullets[0].y;
+    state = updatePlayer(state, IDLE, 16, 16);
+    expect(state.bullets[0].y).toBeLessThan(startY);
+  });
+
+  it('removes bullets with y < -10', () => {
+    const offscreen: PlayerState = {
+      ...createPlayer(),
+      bullets: [{ x: 640, y: -11 }],
+    };
+    const after = updatePlayer(offscreen, IDLE, 16, 0);
+    expect(after.bullets).toHaveLength(0);
+  });
+});

--- a/src/logic/player.ts
+++ b/src/logic/player.ts
@@ -4,7 +4,7 @@ import type { InputState } from '../systems/input';
 const BULLET_SPEED = 600;
 const PLAYER_SPEED = 320;
 const ACCELERATION = 1600;
-const DECELERATION = 2400;
+const DECELERATION = 800;
 const FIRE_RATE_MS = 200;
 
 const Y_MIN = 432;

--- a/src/logic/player.ts
+++ b/src/logic/player.ts
@@ -1,0 +1,93 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+import type { InputState } from '../systems/input';
+
+const BULLET_SPEED = 600;
+const PLAYER_SPEED = 320;
+const ACCELERATION = 1600;
+const DECELERATION = 2400;
+const FIRE_RATE_MS = 200;
+
+const Y_MIN = 432;
+const Y_MAX = 684;
+const CANVAS_WIDTH = 1280;
+
+export interface Bullet {
+  x: number;
+  y: number;
+}
+
+export interface PlayerState {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  hp: number;
+  lastFireMs: number;
+  bullets: Bullet[];
+}
+
+export function createPlayer(): PlayerState {
+  return { x: 640, y: 630, vx: 0, vy: 0, hp: 3, lastFireMs: Number.NEGATIVE_INFINITY, bullets: [] };
+}
+
+export function updatePlayer(
+  state: PlayerState,
+  input: InputState,
+  deltaMs: number,
+  timestamp: number,
+): PlayerState {
+  const dt = deltaMs / 1000;
+
+  // Normalize input magnitude before applying acceleration
+  const inputMagnitude = Math.sqrt(input.moveX ** 2 + input.moveY ** 2);
+  const normalizedX = inputMagnitude > 1 ? input.moveX / inputMagnitude : input.moveX;
+  const normalizedY = inputMagnitude > 1 ? input.moveY / inputMagnitude : input.moveY;
+
+  // Accelerate or decelerate each axis
+  let vx = state.vx;
+  let vy = state.vy;
+
+  if (normalizedX !== 0) {
+    vx += normalizedX * ACCELERATION * dt;
+  } else {
+    const decel = DECELERATION * dt;
+    vx = Math.abs(vx) <= decel ? 0 : vx - Math.sign(vx) * decel;
+  }
+
+  if (normalizedY !== 0) {
+    vy += normalizedY * ACCELERATION * dt;
+  } else {
+    const decel = DECELERATION * dt;
+    vy = Math.abs(vy) <= decel ? 0 : vy - Math.sign(vy) * decel;
+  }
+
+  // Cap combined speed so diagonal movement matches cardinal max speed
+  const speed = Math.sqrt(vx * vx + vy * vy);
+  if (speed > PLAYER_SPEED) {
+    const scale = PLAYER_SPEED / speed;
+    vx *= scale;
+    vy *= scale;
+  }
+
+  // Update position
+  let x = state.x + vx * dt;
+  let y = state.y + vy * dt;
+
+  // Horizontal wrap
+  if (x < 0) x = CANVAS_WIDTH;
+  if (x > CANVAS_WIDTH) x = 0;
+
+  // Vertical clamp
+  y = Math.max(Y_MIN, Math.min(Y_MAX, y));
+
+  // Shooting
+  let { lastFireMs } = state;
+  let bullets = state.bullets.map((b) => ({ x: b.x, y: b.y - BULLET_SPEED * dt })).filter((b) => b.y >= -10);
+
+  if (input.fire && timestamp - lastFireMs >= FIRE_RATE_MS) {
+    bullets = [...bullets, { x, y }];
+    lastFireMs = timestamp;
+  }
+
+  return { x, y, vx, vy, hp: state.hp, lastFireMs, bullets };
+}

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1,13 +1,14 @@
 import Phaser from 'phaser';
 import { createInputManager, InputManager, InputFrame } from '../systems/input';
+import { createPlayer, updatePlayer, PlayerState } from '../logic/player';
 
 const SLOWMO_FACTOR = 0.2;
 
 export class GameScene extends Phaser.Scene {
   private inputManager!: InputManager;
   private inSlowMo = false;
-  private loggedUpdateLogic = false;
-  private loggedDrawScene = false;
+  private playerState!: PlayerState;
+  private graphics!: Phaser.GameObjects.Graphics;
 
   constructor() {
     super({ key: 'GameScene' });
@@ -16,32 +17,34 @@ export class GameScene extends Phaser.Scene {
   create(): void {
     this.inputManager = createInputManager();
     this.events.once('shutdown', () => this.inputManager.dispose());
+    this.playerState = createPlayer();
+    this.graphics = this.add.graphics();
   }
 
   update(time: number, delta: number): void {
     const inputFrame = this.inputManager.update();
     const effectiveDeltaMs = delta * (this.inSlowMo ? SLOWMO_FACTOR : 1);
-    const effectiveDeltaSeconds = effectiveDeltaMs / 1000;
     this.updateLogic(inputFrame, effectiveDeltaMs, time);
     this.drawScene();
-    void effectiveDeltaSeconds;
   }
 
   setSlowMo(active: boolean): void {
     this.inSlowMo = active;
   }
 
-  private updateLogic(_inputFrame: InputFrame, _effectiveDeltaMs: number, _timestamp: number): void {
-    if (!this.loggedUpdateLogic) {
-      console.log('updateLogic stub');
-      this.loggedUpdateLogic = true;
-    }
+  private updateLogic(inputFrame: InputFrame, effectiveDeltaMs: number, timestamp: number): void {
+    this.playerState = updatePlayer(this.playerState, inputFrame.current, effectiveDeltaMs, timestamp);
   }
 
   private drawScene(): void {
-    if (!this.loggedDrawScene) {
-      console.log('drawScene stub');
-      this.loggedDrawScene = true;
+    this.graphics.clear();
+
+    this.graphics.fillStyle(0xffffff);
+    this.graphics.fillRect(this.playerState.x - 24, this.playerState.y - 18, 48, 36);
+
+    this.graphics.fillStyle(0xffff00);
+    for (const bullet of this.playerState.bullets) {
+      this.graphics.fillRect(bullet.x - 2, bullet.y - 5, 4, 10);
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #53

## What changed

- `src/logic/player.ts` -- pure TypeScript player state machine: inertia with configurable acceleration/deceleration, diagonal normalization via combined magnitude cap (not per-axis), horizontal wrap, vertical clamp (432-684), fire-rate-gated shooting (200ms), bullet lifecycle (move up, filter at y < -10)
- `src/logic/player.test.ts` -- 14 Jest tests, 100% coverage on player.ts
- `src/scenes/GameScene.ts` -- wires logic into render loop; draws player as white 48x36 rect, bullets as yellow 4x10 rects via persistent Graphics object

## Implementation note

Diagonal normalization happens at the top of `updatePlayer` on the input values before acceleration. Combined speed capped via magnitude scale after accumulation, not per-axis, so diagonal steady-state speed equals PLAYER_SPEED (320 px/s) exactly.

## Test plan

- [x] `npm run test -- --coverage` -- 41 tests pass, player.ts at 100%
- [x] `npx tsc --noEmit` -- clean
- [x] `npm run lint` -- clean
- [x] `npm run build` -- exits 0
- [ ] Manual verification (run `/test 54`)