### PR TITLE
chore: fix R3 button index to 11, add known gotcha

### DIFF
--- a/docs/known-gotchas.md
+++ b/docs/known-gotchas.md
@@ -5,3 +5,4 @@ Running memory of things that wasted 30+ minutes. Add to this list as issues are
 ## Gamepad API
 
 Gamepad API does not report a connected controller until a button is pressed with the tab focused. Press any button after pairing to wake up `navigator.getGamepads()`.
+- Gamepad API W3C standard mapping: L3 (left stick click) = button 10, R3 (right stick click) = button 11. Easy to mix up. Verify against https://w3c.github.io/gamepad/#remapping if unsure.


### PR DESCRIPTION
## Summary

Closes #

## What changed

- 

## Test plan

- [ ] Unit tests pass (`npm run test`)
- [ ] Typecheck passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] E2E tests pass (`npm run test:e2e`)
- [ ] Manual verification complete (run `/test [N]`)
