### PR TITLE
chore: add next-step separator prompts to all workflow slash commands

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -3,3 +3,12 @@ Implement the plan for $ARGUMENTS.
 Full execution loop: write code, run tests, fix failures.
 Only open a PR when all tests pass.
 PR description must include Closes #[issue number].
+
+After opening the PR, end your response with a next-step prompt in a visually distinctive separator block. Include the issue number, PR number, PR URL, and a creative reference to what was built. Example:
+
+```
+[ * * * * * ]
+Issue #N is implemented -- PR #M is open at <url>.
+Run `/review M` and let's make sure it's airtight before we ship it.
+[ * * * * * ]
+```

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,3 +1,14 @@
 # /project:issue
-Using the template in /prompts/create-github-issues.md, create a GitHub Issue for:
+Using the template in /prompts/create-github-issues.md, draft a GitHub Issue for:
 $ARGUMENTS
+
+Show the draft to Paul and wait for explicit approval before creating it in GitHub.
+
+After Paul approves and the issue is created, end your response with a next-step prompt wrapped in a visually distinctive separator block. Include the issue number, URL, and a creative reference to the code content. Example:
+
+```
+*-*-*-*-*
+Issue #N created and lives at <url>.
+Run `/plan N` and I'll map out how we're building this.
+*-*-*-*-*
+```

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -5,3 +5,11 @@ Follow these constraints:
 - External APIs are mocked with page.route() -- never hit live APIs in tests
 - Scope stays focused -- one feature per plan
 - Flag any architectural decisions that need human review before implementing
+
+After presenting the plan, end your response with a next-step prompt in a visually distinctive separator block. Include the issue number and a creative reference to what's being built. Example:
+
+```
+=-=-=-=-=-=-=
+Issue #N is planned. Run `/implement N` and let's bring it to life.
+=-=-=-=-=-=-=
+```

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -41,12 +41,31 @@ Never approve a PR that fails Pass 1. A well-written PR that doesn't meet the sp
 After both passes complete, end your output with one of:
 
 If APPROVED:
-"## Manual verification
-[List the specific browser checks for this PR, derived from the PR description and AC]
+List the specific browser checks for this PR under a "## Manual verification" heading, derived from the PR description and AC. Then end with a next-step prompt in a visually distinctive separator block. Example:
 
-Run `/test [N]` to start the dev server for manual verification. PR #N is open. After you verify and merge on GitHub, run `/merged N` to sync locally."
+```
+|==========|
+PR #N is approved. Run `/test N` to spin up the dev server and verify in the browser.
+After you confirm and merge on GitHub, run `/merged N` to sync locally.
+|==========|
+```
 
-If CHANGES REQUESTED or QUESTION:
-"PR #N is open. After you merge it on GitHub, run `/merged N` to sync locally."
+If CHANGES REQUESTED:
+List the specific changes needed. Then end with a next-step prompt in a visually distinctive separator block. Example:
+
+```
+|==========|
+PR #N has changes requested. Fix the items above, push to the branch, and run `/review N` again.
+|==========|
+```
+
+If QUESTION:
+Ask the question clearly. Then end with a separator block noting what you're waiting on before you can give a verdict. Example:
+
+```
+|==========|
+PR #N is on hold -- answer the question above and run `/review N` again.
+|==========|
+```
 
 Use the actual PR number obtained via `gh pr view --json number`.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -11,5 +11,12 @@ Steps:
 5. Report: active branch name and dev server URL (http://localhost:5173 unless Vite picks a different port, in which case report the actual port)
 6. Read the PR description and linked issue AC. List the specific things Paul should verify manually in the browser for this PR. Be concrete: not "verify the game works" but "confirm the MenuScene displays SCAVENGER PROTOCOL centered on a black canvas" or "confirm pressing E fires the probe and the game enters slow-mo."
 7. Wait for Paul to confirm manual verification is complete before he merges.
+8. After Paul confirms, end your response with a next-step prompt in a visually distinctive separator block. Include the PR number and URL. Example:
+
+```
+~-~-~-~-~
+PR #N verified. Merge it on GitHub, then run `/merged N` to sync locally and clean up the branch.
+~-~-~-~-~
+```
 
 Note: /test is for post-review manual verification only. Always run /review first. Never run /test on a PR that has not received an APPROVED verdict from /review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,29 @@ Running memory of things that wasted 30+ minutes. Add to this list as issues are
 - docs/diary.md is the project diary, run /reflect at the start of each session and /diary at the end
 - Journal entries (docs/build-journal.md) are drafted by Vega in claude.ai, not via slash command, because they capture strategic decisions made outside of Cursor's context.
 
+## Workflow Sequence and Next-Step Prompts
+
+The standard issue-to-merge sequence is:
+
+1. `/issue` -- Gloom drafts the issue, shows it, and waits for approval before creating
+2. Paul approves -- Gloom creates it and says "Issue #N created. Run `/plan N`."
+3. `/plan N` -- Gloom shows the implementation plan. Paul approves or requests changes.
+4. Paul approves plan -- Gloom says "Run `/implement N` and I'll write the code."
+5. `/implement N` -- Gloom writes code, runs tests, opens PR. Says "PR #N open. Run `/review N`."
+6. `/review N` -- Gloom reviews. If APPROVED, says "Run `/test N` to start the dev server."
+7. `/test N` -- Gloom starts the dev server and lists what to verify manually.
+8. Paul verifies and merges on GitHub -- then runs `/merged N` to sync locally.
+
+After every milestone, Gloom must end the message with an explicit next-step prompt wrapped in a visually distinctive separator block so Paul can spot it immediately when returning from a break. Example:
+
+```
+*-*-*-*-*
+Ready for your approval to create Issue #N in GitHub.
+*-*-*-*-*
+```
+
+The separator style can vary but must visually pop. Always include the issue or PR number. Be creative and reference the actual code content in the message (e.g. "Run `/implement 63` and let's get those entity classes off the stub bench.").
+
 ## AI Personas
 - **Vega**: strategy persona, runs in claude.ai. Handles planning, design iteration, decision review, issue authoring. Reads design-doc.md and tuning.md. Does not write implementation code.
 - **Gloom**: implementation persona, runs in Cursor with Claude Code. Executes plans Vega has reviewed. Writes code, tests, and PRs. Does not make architectural or design decisions unilaterally.


### PR DESCRIPTION
## Summary

- All six workflow slash commands (`/issue`, `/plan`, `/implement`, `/review`, `/test`, plus `CLAUDE.md`) now end with a visually distinctive separator block so the next required action is immediately visible after stepping away
- Each separator includes the relevant issue/PR number, URL, and a creative reference to the code content
- Fixes a bug in `/review`: the CHANGES REQUESTED ending previously said "After you merge it on GitHub" -- incorrect when changes are still outstanding; now says to fix and re-run `/review`

## Files changed

- `CLAUDE.md` -- new "Workflow Sequence and Next-Step Prompts" section documents the full 8-step loop
- `.claude/commands/issue.md` -- draft-first, show approval prompt, separator block on creation
- `.claude/commands/plan.md` -- separator block pointing to `/implement N`
- `.claude/commands/implement.md` -- separator block pointing to `/review N`
- `.claude/commands/review.md` -- separator blocks for APPROVED, CHANGES REQUESTED, and QUESTION verdicts; fixes incorrect "merge" wording on CHANGES REQUESTED
- `.claude/commands/test.md` -- separator block after Paul confirms verification, pointing to merge + `/merged N`

## Test plan

- [ ] No code changes -- verify by reading the diff
- [ ] Confirm no em dashes or emojis were introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)