### PR TITLE
Refactor: Move player, bullet, and probe rendering into entity classes

### DIFF
--- a/src/entities/Bullet.ts
+++ b/src/entities/Bullet.ts
@@ -1,1 +1,0 @@
-export class Bullet {}

--- a/src/entities/Bullets.ts
+++ b/src/entities/Bullets.ts
@@ -1,0 +1,19 @@
+// Phaser render entity only. Reads from logic layer state.
+import Phaser from 'phaser';
+import type { Bullet } from '../logic/player';
+
+export class Bullets {
+  private graphics: Phaser.GameObjects.Graphics;
+
+  constructor(scene: Phaser.Scene) {
+    this.graphics = scene.add.graphics();
+  }
+
+  update(bullets: Bullet[]): void {
+    this.graphics.clear();
+    this.graphics.fillStyle(0xffff00);
+    for (const bullet of bullets) {
+      this.graphics.fillRect(bullet.x - 2, bullet.y - 5, 4, 10);
+    }
+  }
+}

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -1,3 +1,17 @@
 // Phaser render entity only. Reads from logic layer state.
+import Phaser from 'phaser';
+import type { PlayerState } from '../logic/player';
 
-export class Player {}
+export class Player {
+  private graphics: Phaser.GameObjects.Graphics;
+
+  constructor(scene: Phaser.Scene) {
+    this.graphics = scene.add.graphics();
+  }
+
+  update(state: PlayerState): void {
+    this.graphics.clear();
+    this.graphics.fillStyle(0xffffff);
+    this.graphics.fillRect(state.x - 24, state.y - 18, 48, 36);
+  }
+}

--- a/src/entities/Probe.ts
+++ b/src/entities/Probe.ts
@@ -1,1 +1,47 @@
-export class Probe {}
+// Phaser render entity only. Reads from logic layer state.
+// Note: update() accepts timestamp and playerX/playerY beyond the issue spec's (state, reticle)
+// because the tether line needs player position and the charge ring needs elapsed time.
+import Phaser from 'phaser';
+import type { ProbeState, ReticleState } from '../logic/probe';
+
+export class Probe {
+  private graphics: Phaser.GameObjects.Graphics;
+
+  constructor(scene: Phaser.Scene) {
+    this.graphics = scene.add.graphics();
+  }
+
+  update(
+    state: ProbeState,
+    reticle: ReticleState,
+    timestamp: number,
+    playerX: number,
+    playerY: number,
+  ): void {
+    this.graphics.clear();
+
+    if (state.status === 'TARGETING') {
+      this.graphics.lineStyle(2, 0x00ffff);
+      this.graphics.strokeCircle(reticle.x, reticle.y, 8);
+    }
+
+    if (
+      state.status === 'LAUNCHED' ||
+      state.status === 'RETURNING' ||
+      state.status === 'TETHERED'
+    ) {
+      this.graphics.fillStyle(0x00ffff);
+      this.graphics.fillCircle(state.x, state.y, 8);
+    }
+
+    if (state.status === 'TETHERED') {
+      this.graphics.lineStyle(2, 0x00ffff);
+      this.graphics.lineBetween(playerX, playerY, state.x, state.y);
+
+      const elapsed = timestamp - state.tetheredSinceMs;
+      const lineWidth = elapsed >= 2000 ? 8 : elapsed >= 700 ? 4 : 2;
+      this.graphics.lineStyle(lineWidth, 0x00ffff);
+      this.graphics.strokeCircle(state.x, state.y, 16);
+    }
+  }
+}

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -13,6 +13,7 @@ import {
 import { ASSETS } from '../config/assets';
 import { Player } from '../entities/Player';
 import { Bullets } from '../entities/Bullets';
+import { Probe as ProbeEntity } from '../entities/Probe';
 
 const SLOWMO_FACTOR = 0.2;
 // TODO: vary by game state per tuning.md
@@ -27,6 +28,7 @@ export class GameScene extends Phaser.Scene {
   private background!: Phaser.GameObjects.TileSprite;
   private scrollImages: Phaser.GameObjects.Image[] = [];
   // Entity render layer -- creation order determines draw depth (probe < player < bullets < hud)
+  private probeEntity!: ProbeEntity;
   private playerEntity!: Player;
   private bulletsEntity!: Bullets;
   private graphics!: Phaser.GameObjects.Graphics;
@@ -60,6 +62,7 @@ export class GameScene extends Phaser.Scene {
       this.scrollImages = [imgA, imgB];
     }
 
+    this.probeEntity = new ProbeEntity(this);
     this.playerEntity = new Player(this);
     this.bulletsEntity = new Bullets(this);
     this.graphics = this.add.graphics();
@@ -144,12 +147,13 @@ export class GameScene extends Phaser.Scene {
       }
     }
 
-    this.graphics.clear();
+    // Entity rendering -- each entity clears its own Graphics object
+    this.probeEntity.update(probe, reticle, ts, this.playerState.x, this.playerState.y);
+    this.playerEntity.update(this.playerState);
+    this.bulletsEntity.update(this.playerState.bullets);
 
-    // Reticle ring + countdown (TARGETING) / scan cooldown indicator (TARGETING_COOLDOWN)
+    // Countdown timer text (TARGETING) / scan cooldown text (TARGETING_COOLDOWN) -- HUD, stays here
     if (probe.status === 'TARGETING') {
-      this.graphics.lineStyle(2, 0x00ffff);
-      this.graphics.strokeCircle(reticle.x, reticle.y, 8);
       const remaining = Math.max(0, TARGETING_MAX_MS - (ts - probe.targetingStartMs));
       const color = remaining < 500 ? '#ff0000' : remaining < 1500 ? '#ffff00' : '#ffffff';
       this.targetingTimerText.setText(Math.floor(remaining).toString());
@@ -165,32 +169,8 @@ export class GameScene extends Phaser.Scene {
       this.scanCooldownText.setVisible(false);
     }
 
-    // Probe body (LAUNCHED, RETURNING, TETHERED)
-    if (
-      probe.status === 'LAUNCHED' ||
-      probe.status === 'RETURNING' ||
-      probe.status === 'TETHERED'
-    ) {
-      this.graphics.fillStyle(0x00ffff);
-      this.graphics.fillCircle(probe.x, probe.y, 8);
-    }
-
-    // Tether line + charge ring (TETHERED)
-    if (probe.status === 'TETHERED') {
-      this.graphics.lineStyle(2, 0x00ffff);
-      this.graphics.lineBetween(this.playerState.x, this.playerState.y, probe.x, probe.y);
-
-      const elapsed = ts - probe.tetheredSinceMs;
-      const lineWidth = elapsed >= 2000 ? 8 : elapsed >= 700 ? 4 : 2;
-      this.graphics.lineStyle(lineWidth, 0x00ffff);
-      this.graphics.strokeCircle(probe.x, probe.y, 16);
-    }
-
-    this.playerEntity.update(this.playerState);
-
-    this.bulletsEntity.update(this.playerState.bullets);
-
-    // Cooldown bar (top-left, 200px wide)
+    // HUD Graphics (cooldown bar only)
+    this.graphics.clear();
     if (probe.status === 'COOLDOWN' && probe.cooldownTotalMs > 0) {
       const fraction = Math.max(0, (probe.cooldownEndMs - ts) / probe.cooldownTotalMs);
       this.graphics.fillStyle(0x888888);

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -11,6 +11,7 @@ import {
   TARGETING_MAX_MS,
 } from '../logic/probe';
 import { ASSETS } from '../config/assets';
+import { Player } from '../entities/Player';
 
 const SLOWMO_FACTOR = 0.2;
 // TODO: vary by game state per tuning.md
@@ -24,6 +25,8 @@ export class GameScene extends Phaser.Scene {
   private reticleState!: ReticleState;
   private background!: Phaser.GameObjects.TileSprite;
   private scrollImages: Phaser.GameObjects.Image[] = [];
+  // Entity render layer -- creation order determines draw depth (probe < player < bullets < hud)
+  private playerEntity!: Player;
   private graphics!: Phaser.GameObjects.Graphics;
   private flashText!: Phaser.GameObjects.Text;
   private targetingTimerText!: Phaser.GameObjects.Text;
@@ -55,6 +58,7 @@ export class GameScene extends Phaser.Scene {
       this.scrollImages = [imgA, imgB];
     }
 
+    this.playerEntity = new Player(this);
     this.graphics = this.add.graphics();
     this.flashText = this.add
       .text(640, 360, '', { fontSize: '32px', color: '#00ffff' })
@@ -179,9 +183,7 @@ export class GameScene extends Phaser.Scene {
       this.graphics.strokeCircle(probe.x, probe.y, 16);
     }
 
-    // Player ship
-    this.graphics.fillStyle(0xffffff);
-    this.graphics.fillRect(this.playerState.x - 24, this.playerState.y - 18, 48, 36);
+    this.playerEntity.update(this.playerState);
 
     // Bullets
     this.graphics.fillStyle(0xffff00);

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -12,6 +12,7 @@ import {
 } from '../logic/probe';
 import { ASSETS } from '../config/assets';
 import { Player } from '../entities/Player';
+import { Bullets } from '../entities/Bullets';
 
 const SLOWMO_FACTOR = 0.2;
 // TODO: vary by game state per tuning.md
@@ -27,6 +28,7 @@ export class GameScene extends Phaser.Scene {
   private scrollImages: Phaser.GameObjects.Image[] = [];
   // Entity render layer -- creation order determines draw depth (probe < player < bullets < hud)
   private playerEntity!: Player;
+  private bulletsEntity!: Bullets;
   private graphics!: Phaser.GameObjects.Graphics;
   private flashText!: Phaser.GameObjects.Text;
   private targetingTimerText!: Phaser.GameObjects.Text;
@@ -59,6 +61,7 @@ export class GameScene extends Phaser.Scene {
     }
 
     this.playerEntity = new Player(this);
+    this.bulletsEntity = new Bullets(this);
     this.graphics = this.add.graphics();
     this.flashText = this.add
       .text(640, 360, '', { fontSize: '32px', color: '#00ffff' })
@@ -185,11 +188,7 @@ export class GameScene extends Phaser.Scene {
 
     this.playerEntity.update(this.playerState);
 
-    // Bullets
-    this.graphics.fillStyle(0xffff00);
-    for (const bullet of this.playerState.bullets) {
-      this.graphics.fillRect(bullet.x - 2, bullet.y - 5, 4, 10);
-    }
+    this.bulletsEntity.update(this.playerState.bullets);
 
     // Cooldown bar (top-left, 200px wide)
     if (probe.status === 'COOLDOWN' && probe.cooldownTotalMs > 0) {


### PR DESCRIPTION
Closes #64

## Summary

Populates three previously empty entity stubs and removes all entity rendering from `GameScene`. Each entity owns its own `Phaser.GameObjects.Graphics` object and exposes an `update(state)` method called each frame.

- `src/entities/Player.ts` -- renders the player ship (white 48x36 rect)
- `src/entities/Bullets.ts` -- renamed from `Bullet.ts`; renders the full bullet collection (yellow 4x10 rects)
- `src/entities/Probe.ts` -- renders reticle ring (TARGETING), probe body (LAUNCHED/RETURNING/TETHERED), and tether line + charge ring (TETHERED)

`GameScene` retains the cooldown bar (HUD Graphics), reward flash text, countdown timer text, and scan cooldown text. These move to `src/ui/HUD.ts` in a later issue.

Draw depth is determined by creation order in `create()`: probe < player < bullets < HUD.

## Spec deviation: Probe.update() signature

The issue spec defined `update(state: ProbeState, reticle: ReticleState)`. The implementation uses:

```typescript
update(state: ProbeState, reticle: ReticleState, timestamp: number, playerX: number, playerY: number)
```

**Reason:** The tether line requires the player's current position, and the charge ring line-width scaling requires elapsed time since tethering (`timestamp - state.tetheredSinceMs`). Neither is available from `ProbeState` or `ReticleState` alone. These are render-only values passed from `GameScene` -- no logic coupling introduced.

## Verification

- `npx tsc --noEmit` clean after each commit
- `npm run lint` clean after each commit
- `npm run test` -- 66/66 passing after each commit, no test files modified
- `grep -n 'fillRect\|fillCircle\|strokeCircle\|lineBetween\|lineStyle' src/scenes/GameScene.ts` returns exactly one line (cooldown bar)

## Three-commit structure (per issue spec)

1. Player entity -- ship rendering extracted
2. Bullets entity -- bullet collection rendering extracted, `Bullet.ts` renamed to `Bullets.ts`
3. Probe entity -- all probe Graphics extracted

🤖 Generated with [Claude Code](https://claude.com/claude-code)