### PR TITLE
chore: add deploy-on-demand workflow and deployment docs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,45 @@
+name: Deploy to production
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type DEPLOY to confirm production deployment'
+        required: true
+        type: string
+
+# Prevents two simultaneous deploys from racing if Run workflow is clicked twice.
+# cancel-in-progress: false ensures a queued second deploy waits rather than canceling the first.
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to Netlify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate confirmation
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          if [ "$CONFIRM" != "DEPLOY" ]; then
+            echo "ERROR: confirm must be exactly 'DEPLOY'. Got: '$CONFIRM'"
+            exit 1
+          fi
+
+      - name: Trigger Netlify build hook
+        env:
+          HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK }}
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$HOOK_URL")
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "ERROR: Netlify build hook returned HTTP $HTTP_STATUS"
+            exit 1
+          fi
+
+      - name: Log deployment info
+        run: |
+          echo "Commit: ${{ github.sha }}"
+          echo "Actor:  ${{ github.actor }}"
+          echo "Time:   $(date -u '+%Y-%m-%dT%H:%M:%SZ')"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # scavenger-protocol
 Retrofuturistic vertical shmup with tether-probe salvage mechanics. Phaser 3 + TypeScript. Portfolio project.
+
+## Deployment
+
+Production deploys are manual and triggered via GitHub Actions. See [docs/deployment.md](docs/deployment.md) for instructions.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,32 @@
+# Deployment
+
+## Why deploys are manual
+
+Netlify free tier is 300 credits/month. Each production deploy costs 15 credits. Auto-deploy on every merge burned half the monthly budget in a single day of rapid PR merges.
+
+Production deploys are now intentional and batched. Pushing to main does not deploy. The live site is updated only when a developer explicitly triggers a deploy.
+
+## How to trigger a production deploy
+
+1. Go to the GitHub Actions tab in the repository
+2. Select "Deploy to production" from the left sidebar
+3. Click "Run workflow"
+4. Type `DEPLOY` in the confirm field (must be exact -- uppercase, no spaces)
+5. Click "Run workflow"
+
+The workflow POSTs to the Netlify build hook, which queues a build from the current HEAD of `main`. Build progress is visible in the Netlify dashboard.
+
+If "Run workflow" is clicked twice before the first deploy completes, the second run queues and waits -- it does not cancel the first.
+
+## Where to view deploy status
+
+- **GitHub Actions:** the workflow run logs show the commit SHA, actor, and UTC timestamp of the triggered deploy
+- **Netlify dashboard:** full build logs and deploy history for the production site
+
+## Emergency: how to disable
+
+If the manual workflow is broken and a deploy is urgently needed, re-enable auto publishing in the Netlify dashboard:
+
+`Site settings -> Build & deploy -> Continuous deployment -> Start auto publishing`
+
+This bypasses the GitHub workflow entirely and restores the original behavior (deploy on every push to main). Disable again after the emergency is resolved.


### PR DESCRIPTION
Closes #67

## Summary

- Adds `.github/workflows/deploy-production.yml`: manually triggered via `workflow_dispatch`. Requires typing `DEPLOY` to confirm. POSTs to `${{ secrets.NETLIFY_BUILD_HOOK }}`. Validates HTTP 200 response. Logs commit SHA, actor, and UTC timestamp on success.
- Adds `docs/deployment.md`: explains why deploys are manual, how to trigger, where to see status, and how to disable in an emergency.
- Updates `README.md`: adds a Deployment section linking to `docs/deployment.md`.

## Design notes

- `concurrency: group: production-deploy, cancel-in-progress: false` -- queues a second deploy rather than canceling the first if Run workflow is clicked twice
- Secrets injected via `env:` (not interpolated directly in shell strings) -- prevents logging and handles empty-secret edge cases correctly
- `${{ inputs.confirm }}` used consistently -- no `github.event.inputs` anywhere
- No checkout step -- the workflow only triggers Netlify's own build system, which pulls from the repo independently

## Verification (post-merge -- AC #9)

After merging, trigger "Deploy to production" from the GitHub Actions tab with `DEPLOY`. The successful run URL will be added as a comment on this PR.

**If the verification deploy fails:** open a follow-up bug issue against this workflow. Do not revert this PR. Netlify auto-publish is already disabled, so a broken manual workflow is no worse than the pre-PR state. The site continues serving the last successful production build.

## Test plan

- [x] 66/66 Jest tests pass (no src/ changes)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] Post-merge: trigger "Deploy to production" workflow with `DEPLOY`, confirm HTTP 200 and Netlify build queues

🤖 Generated with [Claude Code](https://claude.com/claude-code)