### PR TITLE
feat: Driftlings -- first enemy type, spawner, and collision detection

### DIFF
--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -265,7 +265,7 @@ Visual: dark gray rectangle, 96x72px. Four vents: one each side plus two on bott
 | Descent speed | 80 px/s | Steady downward drift. |
 | Sine amplitude range | 20 to 320 px (capped) | Random per spawn. Capped to keep Driftling inside canvas. |
 | Amplitude edge margin | 50 px | Minimum gap between Driftling path and canvas edge. |
-| Sine frequency | 0.3 to 0.8 Hz | Random per spawn. |
+| Sine frequency | 0.5 to 1.0 Hz | Random per spawn. |
 | Sine phase | 0 to 2*PI rad | Random per spawn. |
 
 ### Spawn schedule

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -254,6 +254,45 @@ Visual: dark gray rectangle, 96x72px. Four vents: one each side plus two on bott
 
 ---
 
+## Driftlings
+
+### Stats
+
+| Stat | Value | Notes |
+|---|---|---|
+| HP | 1 | One bullet kill. |
+| Hitbox radius | 14 px | Matches visual circle radius. |
+| Descent speed | 80 px/s | Steady downward drift. |
+| Sine amplitude range | 20 to 320 px (capped) | Random per spawn. Capped to keep Driftling inside canvas. |
+| Amplitude edge margin | 50 px | Minimum gap between Driftling path and canvas edge. |
+| Sine frequency | 0.3 to 0.8 Hz | Random per spawn. |
+| Sine phase | 0 to 2*PI rad | Random per spawn. |
+
+### Spawn schedule
+
+| Window | Rate | Notes |
+|---|---|---|
+| 0 to 5000 ms | None | Grace period at run start. |
+| 5000 to 25000 ms | 1 per 1500 ms | Early wave: one every 1.5 seconds. |
+| 25000 to 45000 ms | 1 per 800 ms | Escalation: one every 0.8 seconds. |
+| 45000+ ms | None | Placeholder. Full wave scheduler (Issue #73) will take over. |
+
+### Spawn position
+
+| Axis | Rule |
+|---|---|
+| X | Random across [50, 1230] |
+| Y | -20 px (just above canvas top) |
+
+### Collision
+
+| Hit type | Effect |
+|---|---|
+| Bullet hits Driftling | Bullet consumed, Driftling HP -1 (dead at 0) |
+| Player body hits Driftling | Player takes 1 HP damage (invulnerability 1000ms), Driftling dies |
+
+---
+
 ## Wave schedule
 
 ### Timeline

--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -1,1 +1,21 @@
-export class Enemy {}
+// Phaser render entity only. Reads from logic layer state.
+import Phaser from 'phaser';
+import type { Driftling } from '../logic/enemies';
+
+export class Enemy {
+  private graphics: Phaser.GameObjects.Graphics;
+
+  constructor(scene: Phaser.Scene) {
+    this.graphics = scene.add.graphics();
+  }
+
+  update(driftlings: Driftling[]): void {
+    this.graphics.clear();
+    for (const d of driftlings) {
+      this.graphics.lineStyle(1, 0x606060);
+      this.graphics.strokeCircle(d.x, d.y, 14);
+      this.graphics.fillStyle(0xc0c0c0);
+      this.graphics.fillCircle(d.x, d.y, 12);
+    }
+  }
+}

--- a/src/logic/collision.test.ts
+++ b/src/logic/collision.test.ts
@@ -1,0 +1,123 @@
+import { bulletEnemyHits, playerEnemyHits, BULLET_HIT_RADIUS } from './collision';
+import { DRIFTLING_HIT_RADIUS } from './enemies';
+import type { Driftling } from './enemies';
+import type { Bullet } from './player';
+
+function makeDriftling(id: number, x: number, y: number, alive = true): Driftling {
+  return {
+    id,
+    x,
+    y,
+    spawnX: x,
+    amplitude: 0,
+    frequency: 0.5,
+    phase: 0,
+    spawnedAtMs: 0,
+    hp: 1,
+    alive,
+  };
+}
+
+function makeBullet(x: number, y: number): Bullet {
+  return { x, y };
+}
+
+const COMBINED_BULLET = BULLET_HIT_RADIUS + DRIFTLING_HIT_RADIUS; // 18
+const COMBINED_PLAYER = 16 + DRIFTLING_HIT_RADIUS; // 30
+
+describe('bulletEnemyHits', () => {
+  it('returns a hit when bullet is at the center of an enemy', () => {
+    const bullets = [makeBullet(200, 200)];
+    const enemies = [makeDriftling(1, 200, 200)];
+    expect(bulletEnemyHits(bullets, enemies)).toEqual([{ bulletIndex: 0, enemyId: 1 }]);
+  });
+
+  it('returns a hit when bullet is just within the combined radius', () => {
+    // distance = combined - 1, should hit
+    const bullets = [makeBullet(200, 200)];
+    const enemies = [makeDriftling(1, 200 + COMBINED_BULLET - 1, 200)];
+    expect(bulletEnemyHits(bullets, enemies)).toHaveLength(1);
+  });
+
+  it('returns no hit when bullet is just outside the combined radius', () => {
+    // distance = combined + 1, should miss
+    const bullets = [makeBullet(200, 200)];
+    const enemies = [makeDriftling(1, 200 + COMBINED_BULLET + 1, 200)];
+    expect(bulletEnemyHits(bullets, enemies)).toHaveLength(0);
+  });
+
+  it('returns the correct bulletIndex', () => {
+    const bullets = [makeBullet(0, 0), makeBullet(200, 200)];
+    const enemies = [makeDriftling(5, 200, 200)];
+    const hits = bulletEnemyHits(bullets, enemies);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].bulletIndex).toBe(1);
+  });
+
+  it('returns the correct enemyId (uses stable id, not array index)', () => {
+    const bullets = [makeBullet(200, 200)];
+    const enemies = [makeDriftling(42, 200, 200)];
+    const hits = bulletEnemyHits(bullets, enemies);
+    expect(hits[0].enemyId).toBe(42);
+  });
+
+  it('two bullets each hitting different enemies returns two entries', () => {
+    const bullets = [makeBullet(100, 100), makeBullet(300, 300)];
+    const enemies = [makeDriftling(1, 100, 100), makeDriftling(2, 300, 300)];
+    const hits = bulletEnemyHits(bullets, enemies);
+    expect(hits).toHaveLength(2);
+    expect(hits[0]).toEqual({ bulletIndex: 0, enemyId: 1 });
+    expect(hits[1]).toEqual({ bulletIndex: 1, enemyId: 2 });
+  });
+
+  it('skips enemies with alive=false', () => {
+    const bullets = [makeBullet(200, 200)];
+    const enemies = [makeDriftling(1, 200, 200, false)];
+    expect(bulletEnemyHits(bullets, enemies)).toHaveLength(0);
+  });
+
+  it('returns empty array when bullets is empty', () => {
+    const enemies = [makeDriftling(1, 200, 200)];
+    expect(bulletEnemyHits([], enemies)).toHaveLength(0);
+  });
+
+  it('returns empty array when enemies is empty', () => {
+    const bullets = [makeBullet(200, 200)];
+    expect(bulletEnemyHits(bullets, [])).toHaveLength(0);
+  });
+});
+
+describe('playerEnemyHits', () => {
+  const player = { x: 640, y: 600, radius: 16 };
+
+  it('returns enemy id when player overlaps enemy', () => {
+    const enemies = [makeDriftling(7, 640, 600)];
+    expect(playerEnemyHits(player, enemies)).toEqual([7]);
+  });
+
+  it('returns hit when player is just within combined radius', () => {
+    const enemies = [makeDriftling(1, 640 + COMBINED_PLAYER - 1, 600)];
+    expect(playerEnemyHits(player, enemies)).toHaveLength(1);
+  });
+
+  it('returns no hit when player is just outside combined radius', () => {
+    const enemies = [makeDriftling(1, 640 + COMBINED_PLAYER + 1, 600)];
+    expect(playerEnemyHits(player, enemies)).toHaveLength(0);
+  });
+
+  it('returns multiple ids when player overlaps multiple enemies', () => {
+    const enemies = [makeDriftling(3, 640, 600), makeDriftling(4, 641, 601)];
+    const ids = playerEnemyHits(player, enemies);
+    expect(ids).toContain(3);
+    expect(ids).toContain(4);
+  });
+
+  it('skips enemies with alive=false', () => {
+    const enemies = [makeDriftling(1, 640, 600, false)];
+    expect(playerEnemyHits(player, enemies)).toHaveLength(0);
+  });
+
+  it('returns empty array when enemies is empty', () => {
+    expect(playerEnemyHits(player, [])).toHaveLength(0);
+  });
+});

--- a/src/logic/collision.ts
+++ b/src/logic/collision.ts
@@ -1,0 +1,51 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+// Circle-circle collision using squared distance. No Math.sqrt.
+import type { Bullet } from './player';
+import type { Driftling } from './enemies';
+import { DRIFTLING_HIT_RADIUS } from './enemies';
+
+export const BULLET_HIT_RADIUS = 4;
+
+function circlesOverlap(
+  ax: number,
+  ay: number,
+  ar: number,
+  bx: number,
+  by: number,
+  br: number,
+): boolean {
+  const dx = ax - bx;
+  const dy = ay - by;
+  const sumR = ar + br;
+  return dx * dx + dy * dy < sumR * sumR;
+}
+
+export function bulletEnemyHits(
+  bullets: Bullet[],
+  enemies: Driftling[],
+): { bulletIndex: number; enemyId: number }[] {
+  const hits: { bulletIndex: number; enemyId: number }[] = [];
+  for (let bi = 0; bi < bullets.length; bi++) {
+    for (const enemy of enemies) {
+      if (!enemy.alive) continue;
+      if (circlesOverlap(bullets[bi].x, bullets[bi].y, BULLET_HIT_RADIUS, enemy.x, enemy.y, DRIFTLING_HIT_RADIUS)) {
+        hits.push({ bulletIndex: bi, enemyId: enemy.id });
+      }
+    }
+  }
+  return hits;
+}
+
+export function playerEnemyHits(
+  player: { x: number; y: number; radius: number },
+  enemies: Driftling[],
+): number[] {
+  const ids: number[] = [];
+  for (const enemy of enemies) {
+    if (!enemy.alive) continue;
+    if (circlesOverlap(player.x, player.y, player.radius, enemy.x, enemy.y, DRIFTLING_HIT_RADIUS)) {
+      ids.push(enemy.id);
+    }
+  }
+  return ids;
+}

--- a/src/logic/enemies.test.ts
+++ b/src/logic/enemies.test.ts
@@ -1,0 +1,85 @@
+import { updateDriftlings, Driftling } from './enemies';
+
+function makeDriftling(overrides: Partial<Driftling> = {}): Driftling {
+  return {
+    id: 1,
+    x: 640,
+    y: 100,
+    spawnX: 640,
+    amplitude: 80,
+    frequency: 0.5,
+    phase: 0,
+    spawnedAtMs: 0,
+    hp: 1,
+    alive: true,
+    ...overrides,
+  };
+}
+
+describe('updateDriftlings -- determinism', () => {
+  it('same inputs produce identical output', () => {
+    const driftlings = [makeDriftling()];
+    const a = updateDriftlings(driftlings, 100, 1000);
+    const b = updateDriftlings(driftlings, 100, 1000);
+    expect(a).toEqual(b);
+  });
+});
+
+describe('updateDriftlings -- sine motion', () => {
+  it('at elapsed=0 (spawnedAtMs === currentTimeMs), x equals spawnX + amplitude * sin(phase)', () => {
+    const phase = Math.PI / 4;
+    const d = makeDriftling({ spawnedAtMs: 5000, phase, amplitude: 100, frequency: 0.5 });
+    const result = updateDriftlings([d], 16, 5000);
+    const expected = 640 + 100 * Math.sin(phase);
+    expect(result[0].x).toBeCloseTo(expected, 10);
+  });
+
+  it('x oscillates around spawnX -- positive half-cycle', () => {
+    // At elapsed = 0.5s with frequency=1Hz, sin(2*PI*1*0.5 + 0) = sin(PI) ≈ 0
+    const d = makeDriftling({ spawnedAtMs: 0, amplitude: 100, frequency: 1, phase: 0 });
+    const result = updateDriftlings([d], 16, 500);
+    expect(result[0].x).toBeCloseTo(640 + 100 * Math.sin(2 * Math.PI * 1 * 0.5), 10);
+  });
+});
+
+describe('updateDriftlings -- vertical descent', () => {
+  it('y increases by DESCENT_SPEED * dt each frame', () => {
+    const d = makeDriftling({ y: 200 });
+    const deltaMs = 100;
+    const result = updateDriftlings([d], deltaMs, 1000);
+    // DESCENT_SPEED = 80, dt = 0.1s, expected descent = 8px
+    expect(result[0].y).toBeCloseTo(208, 5);
+  });
+});
+
+describe('updateDriftlings -- lifecycle filtering', () => {
+  it('removes driftlings with alive=false', () => {
+    const dead = makeDriftling({ alive: false });
+    expect(updateDriftlings([dead], 16, 1000)).toHaveLength(0);
+  });
+
+  it('keeps alive driftlings', () => {
+    const live = makeDriftling({ alive: true });
+    expect(updateDriftlings([live], 16, 1000)).toHaveLength(1);
+  });
+
+  it('removes driftlings that descend past y=740', () => {
+    // y=735, descent 80px/s over 100ms = 8px -> ends at 743, removed
+    const d = makeDriftling({ y: 735 });
+    expect(updateDriftlings([d], 100, 1000)).toHaveLength(0);
+  });
+
+  it('keeps driftlings still on screen after descent', () => {
+    const d = makeDriftling({ y: 200 });
+    expect(updateDriftlings([d], 100, 1000)).toHaveLength(1);
+  });
+
+  it('mixed array: returns only alive and on-screen', () => {
+    const live = makeDriftling({ id: 1, y: 200 });
+    const dead = makeDriftling({ id: 2, alive: false });
+    const offscreen = makeDriftling({ id: 3, y: 738 });
+    const result = updateDriftlings([live, dead, offscreen], 100, 1000);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
+  });
+});

--- a/src/logic/enemies.ts
+++ b/src/logic/enemies.ts
@@ -1,0 +1,36 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+
+export const DRIFTLING_HIT_RADIUS = 14;
+const DESCENT_SPEED = 80; // px/s
+
+export interface Driftling {
+  id: number;
+  x: number;
+  y: number;
+  spawnX: number;
+  amplitude: number;
+  frequency: number;
+  phase: number;
+  spawnedAtMs: number;
+  hp: number;
+  alive: boolean;
+}
+
+export function updateDriftlings(
+  driftlings: Driftling[],
+  deltaMs: number,
+  currentTimeMs: number,
+): Driftling[] {
+  const dt = deltaMs / 1000;
+  return driftlings
+    .filter((d) => d.alive)
+    .map((d) => {
+      const elapsedSec = (currentTimeMs - d.spawnedAtMs) / 1000;
+      return {
+        ...d,
+        x: d.spawnX + d.amplitude * Math.sin(2 * Math.PI * d.frequency * elapsedSec + d.phase),
+        y: d.y + DESCENT_SPEED * dt,
+      };
+    })
+    .filter((d) => d.y <= 740);
+}

--- a/src/logic/player.test.ts
+++ b/src/logic/player.test.ts
@@ -27,6 +27,7 @@ describe('createPlayer', () => {
     expect(p.hp).toBe(3);
     expect(p.fireTimer).toBe(0);
     expect(p.bullets).toHaveLength(0);
+    expect(p.invulnerabilityEndMs).toBe(0);
   });
 });
 

--- a/src/logic/player.ts
+++ b/src/logic/player.ts
@@ -6,6 +6,9 @@ const PLAYER_SPEED = 320;
 const ACCELERATION = 1600;
 const DECELERATION = 800;
 const FIRE_RATE_MS = 200;
+const INVULNERABILITY_MS = 1000;
+
+export const PLAYER_HIT_RADIUS = 16;
 
 const Y_MIN = 432;
 const Y_MAX = 684;
@@ -24,10 +27,16 @@ export interface PlayerState {
   hp: number;
   fireTimer: number;
   bullets: Bullet[];
+  invulnerabilityEndMs: number;
 }
 
 export function createPlayer(): PlayerState {
-  return { x: 640, y: 630, vx: 0, vy: 0, hp: 3, fireTimer: 0, bullets: [] };
+  return { x: 640, y: 630, vx: 0, vy: 0, hp: 3, fireTimer: 0, bullets: [], invulnerabilityEndMs: 0 };
+}
+
+export function damagePlayer(state: PlayerState, timestamp: number): PlayerState {
+  if (timestamp < state.invulnerabilityEndMs) return state;
+  return { ...state, hp: state.hp - 1, invulnerabilityEndMs: timestamp + INVULNERABILITY_MS };
 }
 
 export function updatePlayer(
@@ -88,5 +97,5 @@ export function updatePlayer(
     fireTimer = 0;
   }
 
-  return { x, y, vx, vy, hp: state.hp, fireTimer, bullets };
+  return { x, y, vx, vy, hp: state.hp, fireTimer, bullets, invulnerabilityEndMs: state.invulnerabilityEndMs };
 }

--- a/src/logic/spawner.test.ts
+++ b/src/logic/spawner.test.ts
@@ -86,16 +86,7 @@ describe('spawner -- schedule timing', () => {
 describe('spawner -- amplitude constraint', () => {
   it('amplitude at x=100 never exceeds 50', () => {
     // Edge margin: maxLeft = 100 - 50 = 50, maxRight = 1230 - 100 = 1130, max = 50
-    const rng = createRng('amplitude-edge-left');
-    let state = createSpawner();
-    const spawned = [];
-    for (let t = 0; t <= 45000; t += 100) {
-      const result = updateSpawner(state, rng, t);
-      state = result.state;
-      spawned.push(...result.spawned.filter((d) => d.spawnX === 100));
-    }
-    // We can't guarantee spawnX=100 from random; instead verify the constraint directly
-    // by checking that amplitude <= min(spawnX - 50, 1230 - spawnX) for all spawned
+    // Can't guarantee spawnX=100 from random; verify the constraint for all spawned instead
     const { allSpawned } = advanceToTime(createSpawner(), 45000);
     for (const d of allSpawned) {
       const maxLeft = d.spawnX - 50;

--- a/src/logic/spawner.test.ts
+++ b/src/logic/spawner.test.ts
@@ -1,0 +1,165 @@
+import { createSpawner, updateSpawner, SpawnerState } from './spawner';
+import { createRng } from './rng';
+
+function advanceToTime(
+  state: SpawnerState,
+  targetMs: number,
+  stepMs = 100,
+): { state: SpawnerState; allSpawned: ReturnType<typeof updateSpawner>['spawned'] } {
+  const rng = createRng('test-seed');
+  let current = state;
+  const allSpawned: ReturnType<typeof updateSpawner>['spawned'] = [];
+  for (let t = 0; t <= targetMs; t += stepMs) {
+    const result = updateSpawner(current, rng, t);
+    current = result.state;
+    allSpawned.push(...result.spawned);
+  }
+  return { state: current, allSpawned };
+}
+
+describe('spawner -- determinism', () => {
+  it('same seed and time sequence produces identical driftlings', () => {
+    const runA = (seed: string) => {
+      const rng = createRng(seed);
+      let state = createSpawner();
+      const spawned = [];
+      for (let t = 0; t <= 30000; t += 100) {
+        const result = updateSpawner(state, rng, t);
+        state = result.state;
+        spawned.push(...result.spawned);
+      }
+      return spawned;
+    };
+
+    const a = runA('determinism-seed');
+    const rng2 = createRng('determinism-seed');
+    let state2 = createSpawner();
+    const b = [];
+    for (let t = 0; t <= 30000; t += 100) {
+      const result = updateSpawner(state2, rng2, t);
+      state2 = result.state;
+      b.push(...result.spawned);
+    }
+
+    expect(a).toEqual(b);
+  });
+});
+
+describe('spawner -- schedule timing', () => {
+  it('produces no spawns before 5000ms', () => {
+    const rng = createRng('timing-seed');
+    let state = createSpawner();
+    for (let t = 0; t < 5000; t += 100) {
+      const result = updateSpawner(state, rng, t);
+      state = result.state;
+      expect(result.spawned).toHaveLength(0);
+    }
+  });
+
+  it('first spawn occurs at 5000ms', () => {
+    const rng = createRng('first-spawn-seed');
+    let state = createSpawner();
+    for (let t = 0; t < 5000; t += 100) {
+      const r = updateSpawner(state, rng, t);
+      state = r.state;
+    }
+    const result = updateSpawner(state, rng, 5000);
+    expect(result.spawned).toHaveLength(1);
+  });
+
+  it('produces no spawns at or after 45000ms', () => {
+    const rng = createRng('stop-seed');
+    let state = createSpawner();
+    // Advance to just before stop
+    for (let t = 0; t < 45000; t += 100) {
+      const r = updateSpawner(state, rng, t);
+      state = r.state;
+    }
+    // At and beyond 45000ms, nothing spawns
+    for (let t = 45000; t <= 50000; t += 100) {
+      const result = updateSpawner(state, rng, t);
+      expect(result.spawned).toHaveLength(0);
+    }
+  });
+});
+
+describe('spawner -- amplitude constraint', () => {
+  it('amplitude at x=100 never exceeds 50', () => {
+    // Edge margin: maxLeft = 100 - 50 = 50, maxRight = 1230 - 100 = 1130, max = 50
+    const rng = createRng('amplitude-edge-left');
+    let state = createSpawner();
+    const spawned = [];
+    for (let t = 0; t <= 45000; t += 100) {
+      const result = updateSpawner(state, rng, t);
+      state = result.state;
+      spawned.push(...result.spawned.filter((d) => d.spawnX === 100));
+    }
+    // We can't guarantee spawnX=100 from random; instead verify the constraint directly
+    // by checking that amplitude <= min(spawnX - 50, 1230 - spawnX) for all spawned
+    const { allSpawned } = advanceToTime(createSpawner(), 45000);
+    for (const d of allSpawned) {
+      const maxLeft = d.spawnX - 50;
+      const maxRight = 1230 - d.spawnX;
+      const maxAllowed = Math.min(maxLeft, maxRight);
+      expect(d.amplitude).toBeLessThanOrEqual(maxAllowed + 0.001); // float tolerance
+      expect(d.amplitude).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it('amplitude at x=640 (center) can reach up to 320', () => {
+    // maxLeft = 640 - 50 = 590, maxRight = 1230 - 640 = 590, min = 590 > 320, so max is 320
+    // Run many seeds to find a spawn near x=640 with amplitude close to 320
+    let maxAmplitude = 0;
+    for (let seed = 0; seed < 200; seed++) {
+      const rng = createRng(seed);
+      let state = createSpawner();
+      for (let t = 0; t <= 45000; t += 100) {
+        const result = updateSpawner(state, rng, t);
+        state = result.state;
+        for (const d of result.spawned) {
+          if (d.spawnX >= 400 && d.spawnX <= 880) {
+            maxAmplitude = Math.max(maxAmplitude, d.amplitude);
+          }
+        }
+      }
+    }
+    // Across 200 seeds, a center spawn should occasionally reach near max
+    expect(maxAmplitude).toBeGreaterThan(200);
+  });
+
+  it('all spawned driftlings satisfy the amplitude constraint', () => {
+    const { allSpawned } = advanceToTime(createSpawner(), 45000);
+    for (const d of allSpawned) {
+      const maxLeft = d.spawnX - 50;
+      const maxRight = 1230 - d.spawnX;
+      const maxAllowed = Math.min(maxLeft, maxRight);
+      expect(d.amplitude).toBeLessThanOrEqual(Math.min(320, maxAllowed) + 0.001);
+    }
+  });
+});
+
+describe('spawner -- monotonic ids', () => {
+  it('each spawned driftling has a unique monotonically increasing id', () => {
+    const { allSpawned } = advanceToTime(createSpawner(), 30000);
+    for (let i = 0; i < allSpawned.length; i++) {
+      expect(allSpawned[i].id).toBe(i);
+    }
+  });
+});
+
+describe('spawner -- spawn position', () => {
+  it('all driftlings spawn at y=-20', () => {
+    const { allSpawned } = advanceToTime(createSpawner(), 30000);
+    for (const d of allSpawned) {
+      expect(d.y).toBe(-20);
+    }
+  });
+
+  it('all driftlings spawn with x within [100, 1180]', () => {
+    const { allSpawned } = advanceToTime(createSpawner(), 45000);
+    for (const d of allSpawned) {
+      expect(d.spawnX).toBeGreaterThanOrEqual(100);
+      expect(d.spawnX).toBeLessThanOrEqual(1180);
+    }
+  });
+});

--- a/src/logic/spawner.ts
+++ b/src/logic/spawner.ts
@@ -1,0 +1,66 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+import type { Rng } from './rng';
+import type { Driftling } from './enemies';
+
+const SPAWN_DELAY_MS = 5000;
+const SPAWN_STOP_MS = 45000;
+const INTERVAL_EARLY_MS = 1500; // 5s to 25s
+const INTERVAL_LATE_MS = 800;   // 25s to 45s
+const LATE_PHASE_MS = 25000;
+
+const SPAWN_X_MIN = 100;
+const SPAWN_X_MAX = 1180;
+const AMPLITUDE_MIN = 20;
+const AMPLITUDE_MAX = 320;
+const AMPLITUDE_EDGE_MARGIN = 50;
+const AMPLITUDE_CANVAS_EDGE = 1230;
+const FREQUENCY_MIN = 0.5;
+const FREQUENCY_MAX = 1.0;
+const SPAWN_Y = -20;
+
+export interface SpawnerState {
+  nextSpawnAtMs: number;
+  nextId: number;
+}
+
+export function createSpawner(): SpawnerState {
+  return { nextSpawnAtMs: SPAWN_DELAY_MS, nextId: 0 };
+}
+
+export function updateSpawner(
+  state: SpawnerState,
+  rng: Rng,
+  currentTimeMs: number,
+): { state: SpawnerState; spawned: Driftling[] } {
+  if (currentTimeMs < state.nextSpawnAtMs || currentTimeMs >= SPAWN_STOP_MS) {
+    return { state, spawned: [] };
+  }
+
+  const spawnX = rng.nextInt(SPAWN_X_MIN, SPAWN_X_MAX);
+  const maxLeft = spawnX - AMPLITUDE_EDGE_MARGIN;
+  const maxRight = AMPLITUDE_CANVAS_EDGE - spawnX;
+  const maxAllowed = Math.min(maxLeft, maxRight);
+  const amplitude = rng.nextFloat(AMPLITUDE_MIN, Math.min(AMPLITUDE_MAX, maxAllowed));
+  const frequency = rng.nextFloat(FREQUENCY_MIN, FREQUENCY_MAX);
+  const phase = rng.nextFloat(0, 2 * Math.PI);
+
+  const spawned: Driftling = {
+    id: state.nextId,
+    x: spawnX,
+    y: SPAWN_Y,
+    spawnX,
+    amplitude,
+    frequency,
+    phase,
+    spawnedAtMs: currentTimeMs,
+    hp: 1,
+    alive: true,
+  };
+
+  const interval = currentTimeMs >= LATE_PHASE_MS ? INTERVAL_LATE_MS : INTERVAL_EARLY_MS;
+
+  return {
+    state: { nextSpawnAtMs: state.nextSpawnAtMs + interval, nextId: state.nextId + 1 },
+    spawned: [spawned],
+  };
+}

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1,6 +1,6 @@
 import Phaser from 'phaser';
 import { createInputManager, InputManager, InputFrame, LogicalAction } from '../systems/input';
-import { createPlayer, updatePlayer, PlayerState } from '../logic/player';
+import { createPlayer, updatePlayer, damagePlayer, PlayerState, PLAYER_HIT_RADIUS } from '../logic/player';
 import {
   createProbe,
   updateProbe,
@@ -10,10 +10,15 @@ import {
   ReticleState,
   TARGETING_MAX_MS,
 } from '../logic/probe';
+import { updateDriftlings, Driftling } from '../logic/enemies';
+import { createSpawner, updateSpawner, SpawnerState } from '../logic/spawner';
+import { bulletEnemyHits, playerEnemyHits } from '../logic/collision';
+import { createRng, Rng } from '../logic/rng';
 import { ASSETS } from '../config/assets';
 import { Player } from '../entities/Player';
 import { Bullets } from '../entities/Bullets';
 import { Probe as ProbeEntity } from '../entities/Probe';
+import { Enemy } from '../entities/Enemy';
 
 const SLOWMO_FACTOR = 0.2;
 // TODO: vary by game state per tuning.md
@@ -31,6 +36,10 @@ export class GameScene extends Phaser.Scene {
   private probeEntity!: ProbeEntity;
   private playerEntity!: Player;
   private bulletsEntity!: Bullets;
+  private driftlings: Driftling[] = [];
+  private spawnerState!: SpawnerState;
+  private spawnerRng!: Rng;
+  private enemyEntity!: Enemy;
   private graphics!: Phaser.GameObjects.Graphics;
   private flashText!: Phaser.GameObjects.Text;
   private targetingTimerText!: Phaser.GameObjects.Text;
@@ -62,7 +71,11 @@ export class GameScene extends Phaser.Scene {
       this.scrollImages = [imgA, imgB];
     }
 
+    this.spawnerState = createSpawner();
+    this.spawnerRng = createRng('run-seed-spawner');
+
     this.probeEntity = new ProbeEntity(this);
+    this.enemyEntity = new Enemy(this);
     this.playerEntity = new Player(this);
     this.bulletsEntity = new Bullets(this);
     this.graphics = this.add.graphics();
@@ -124,6 +137,33 @@ export class GameScene extends Phaser.Scene {
     }
 
     this.setSlowMo(this.probeState.status === 'TARGETING');
+
+    const { state: newSpawner, spawned } = updateSpawner(this.spawnerState, this.spawnerRng, timestamp);
+    this.spawnerState = newSpawner;
+    this.driftlings = [...this.driftlings, ...spawned];
+    this.driftlings = updateDriftlings(this.driftlings, effectiveDeltaMs, timestamp);
+
+    const bHits = bulletEnemyHits(this.playerState.bullets, this.driftlings);
+    const pHits = playerEnemyHits(
+      { x: this.playerState.x, y: this.playerState.y, radius: PLAYER_HIT_RADIUS },
+      this.driftlings,
+    );
+
+    const hitBulletIndices = new Set(bHits.map((h) => h.bulletIndex));
+    const hitByBullet = new Set(bHits.map((h) => h.enemyId));
+    this.playerState = {
+      ...this.playerState,
+      bullets: this.playerState.bullets.filter((_, i) => !hitBulletIndices.has(i)),
+    };
+    this.driftlings = this.driftlings.map((d) =>
+      hitByBullet.has(d.id) ? { ...d, hp: d.hp - 1, alive: d.hp - 1 > 0 } : d,
+    );
+
+    if (pHits.length > 0) {
+      this.playerState = damagePlayer(this.playerState, timestamp);
+      const hitByPlayer = new Set(pHits);
+      this.driftlings = this.driftlings.map((d) => (hitByPlayer.has(d.id) ? { ...d, alive: false } : d));
+    }
   }
 
   private drawScene(): void {
@@ -149,6 +189,7 @@ export class GameScene extends Phaser.Scene {
 
     // Entity rendering -- each entity clears its own Graphics object
     this.probeEntity.update(probe, reticle, ts, this.playerState.x, this.playerState.y);
+    this.enemyEntity.update(this.driftlings);
     this.playerEntity.update(this.playerState);
     this.bulletsEntity.update(this.playerState.bullets);
 


### PR DESCRIPTION
## Summary

- Adds `Driftling` enemy type: descends at 80 px/s with a per-spawn sine wave trajectory
- Adds deterministic spawner: grace period 0-5s, one per 1500ms from 5-25s, one per 800ms from 25-45s
- Adds circle-circle collision: bullet kills Driftling, player contact damages player (1000ms i-frames) and kills Driftling
- Adds `Enemy` render entity with gray circle visuals
- Wires everything into `GameScene` (spawn, update, draw, collision resolution each frame)
- Codifies all tuning values in `docs/tuning.md`

## Commits

1. `src/logic/enemies.ts` + `enemies.test.ts` (9 tests)
2. `src/logic/spawner.ts` + `spawner.test.ts` (10 tests)
3. `src/logic/collision.ts` + `collision.test.ts` (15 tests)
4. `src/entities/Enemy.ts` + `src/logic/player.ts` + `src/scenes/GameScene.ts` wiring
5. `docs/tuning.md` Driftling section

Closes #69