### PR TITLE
feat: Husks, wrecks, and probe salvage loop (#75)

### DIFF
--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -1,6 +1,6 @@
 // Phaser render entity only. Reads from logic layer state.
 import Phaser from 'phaser';
-import type { Driftling } from '../logic/enemies';
+import type { Driftling, Husk } from '../logic/enemies';
 
 export class Enemy {
   private graphics: Phaser.GameObjects.Graphics;
@@ -9,13 +9,17 @@ export class Enemy {
     this.graphics = scene.add.graphics();
   }
 
-  update(driftlings: Driftling[]): void {
+  update(driftlings: Driftling[], husks: Husk[]): void {
     this.graphics.clear();
     for (const d of driftlings.filter((d) => d.alive)) {
       this.graphics.lineStyle(1, 0x606060);
       this.graphics.strokeCircle(d.x, d.y, 14);
       this.graphics.fillStyle(0xc0c0c0);
       this.graphics.fillCircle(d.x, d.y, 12);
+    }
+    for (const h of husks.filter((h) => h.alive)) {
+      this.graphics.fillStyle(0x808080);
+      this.graphics.fillRect(h.x - 20, h.y - 20, 40, 40);
     }
   }
 }

--- a/src/entities/Wreck.ts
+++ b/src/entities/Wreck.ts
@@ -1,1 +1,21 @@
-export class Wreck {}
+// Phaser render entity only. Reads from logic layer state.
+import Phaser from 'phaser';
+import type { Wreck as WreckLogic } from '../logic/wreck';
+
+export class Wreck {
+  private graphics: Phaser.GameObjects.Graphics;
+
+  constructor(scene: Phaser.Scene) {
+    this.graphics = scene.add.graphics();
+  }
+
+  update(wrecks: WreckLogic[], candidateWreckId: number | null = null): void {
+    this.graphics.clear();
+    for (const w of wrecks.filter((w) => w.alive)) {
+      const half = 16 * w.scale;
+      // TODO: when candidateWreckId === w.id, render with brighter/pulsing outline to show probe lock candidate
+      this.graphics.lineStyle(1, 0x808080);
+      this.graphics.strokeRect(w.x - half, w.y - half, half * 2, half * 2);
+    }
+  }
+}

--- a/src/entities/Wreck.ts
+++ b/src/entities/Wreck.ts
@@ -9,7 +9,7 @@ export class Wreck {
     this.graphics = scene.add.graphics();
   }
 
-  update(wrecks: WreckLogic[], candidateWreckId: number | null = null): void {
+  update(wrecks: WreckLogic[], _candidateWreckId: number | null = null): void {
     this.graphics.clear();
     for (const w of wrecks.filter((w) => w.alive)) {
       const half = 16 * w.scale;

--- a/src/logic/collision.test.ts
+++ b/src/logic/collision.test.ts
@@ -1,6 +1,8 @@
-import { bulletEnemyHits, playerEnemyHits, BULLET_HIT_RADIUS } from './collision';
-import { DRIFTLING_HIT_RADIUS } from './enemies';
-import type { Driftling } from './enemies';
+import { bulletEnemyHits, playerEnemyHits, bulletHuskHits, playerHuskHits, playerWreckHits, BULLET_HIT_RADIUS } from './collision';
+import { DRIFTLING_HIT_RADIUS, HUSK_HIT_RADIUS } from './enemies';
+import type { Driftling, Husk } from './enemies';
+import { WRECK_HIT_RADIUS } from './wreck';
+import type { Wreck } from './wreck';
 import type { Bullet } from './player';
 
 function makeDriftling(id: number, x: number, y: number, alive = true): Driftling {
@@ -119,5 +121,99 @@ describe('playerEnemyHits', () => {
 
   it('returns empty array when enemies is empty', () => {
     expect(playerEnemyHits(player, [])).toHaveLength(0);
+  });
+});
+
+function makeHusk(id: number, x: number, y: number, alive = true): Husk {
+  return { id, x, y, hp: 4, alive, spawnedAtMs: 0 };
+}
+
+function makeWreck(id: number, x: number, y: number, phase: 'settled' | 'falling' = 'settled', alive = true): Wreck {
+  return { id, x, y, vx: 0, vy: 25, phase, settledAt: 0, scale: 1.0, alive };
+}
+
+const COMBINED_BULLET_HUSK = BULLET_HIT_RADIUS + HUSK_HIT_RADIUS; // 28
+const COMBINED_PLAYER_HUSK = 16 + HUSK_HIT_RADIUS; // 40
+const COMBINED_PLAYER_WRECK = 16 + WRECK_HIT_RADIUS; // 32
+
+describe('bulletHuskHits', () => {
+  it('returns a hit when bullet is at the center of a husk', () => {
+    const bullets = [makeBullet(200, 200)];
+    const husks = [makeHusk(1, 200, 200)];
+    expect(bulletHuskHits(bullets, husks)).toEqual([{ bulletIndex: 0, huskId: 1 }]);
+  });
+
+  it('returns a hit within combined radius', () => {
+    const bullets = [makeBullet(200, 200)];
+    const husks = [makeHusk(1, 200 + COMBINED_BULLET_HUSK - 1, 200)];
+    expect(bulletHuskHits(bullets, husks)).toHaveLength(1);
+  });
+
+  it('returns no hit outside combined radius', () => {
+    const bullets = [makeBullet(200, 200)];
+    const husks = [makeHusk(1, 200 + COMBINED_BULLET_HUSK + 1, 200)];
+    expect(bulletHuskHits(bullets, husks)).toHaveLength(0);
+  });
+
+  it('skips husks with alive=false', () => {
+    const bullets = [makeBullet(200, 200)];
+    const husks = [makeHusk(1, 200, 200, false)];
+    expect(bulletHuskHits(bullets, husks)).toHaveLength(0);
+  });
+
+  it('returns empty when husks is empty', () => {
+    expect(bulletHuskHits([makeBullet(200, 200)], [])).toHaveLength(0);
+  });
+});
+
+describe('playerHuskHits', () => {
+  const player = { x: 640, y: 600, radius: 16 };
+
+  it('returns husk id when player overlaps husk', () => {
+    expect(playerHuskHits(player, [makeHusk(5, 640, 600)])).toEqual([5]);
+  });
+
+  it('returns hit within combined radius', () => {
+    expect(playerHuskHits(player, [makeHusk(1, 640 + COMBINED_PLAYER_HUSK - 1, 600)])).toHaveLength(1);
+  });
+
+  it('returns no hit outside combined radius', () => {
+    expect(playerHuskHits(player, [makeHusk(1, 640 + COMBINED_PLAYER_HUSK + 1, 600)])).toHaveLength(0);
+  });
+
+  it('skips husks with alive=false', () => {
+    expect(playerHuskHits(player, [makeHusk(1, 640, 600, false)])).toHaveLength(0);
+  });
+
+  it('returns empty when husks is empty', () => {
+    expect(playerHuskHits(player, [])).toHaveLength(0);
+  });
+});
+
+describe('playerWreckHits', () => {
+  const player = { x: 640, y: 600, radius: 16 };
+
+  it('returns wreck id when player overlaps settled wreck', () => {
+    expect(playerWreckHits(player, [makeWreck(3, 640, 600)])).toEqual([3]);
+  });
+
+  it('returns hit within combined radius for settled wreck', () => {
+    expect(playerWreckHits(player, [makeWreck(1, 640 + COMBINED_PLAYER_WRECK - 1, 600)])).toHaveLength(1);
+  });
+
+  it('returns no hit outside combined radius', () => {
+    expect(playerWreckHits(player, [makeWreck(1, 640 + COMBINED_PLAYER_WRECK + 1, 600)])).toHaveLength(0);
+  });
+
+  it('skips falling wrecks', () => {
+    expect(playerWreckHits(player, [makeWreck(1, 640, 600, 'falling')])).toHaveLength(0);
+  });
+
+  it('skips wrecks with alive=false', () => {
+    expect(playerWreckHits(player, [makeWreck(1, 640, 600, 'settled', false)])).toHaveLength(0);
+  });
+
+  it('returns empty when wrecks is empty', () => {
+    expect(playerWreckHits(player, [])).toHaveLength(0);
   });
 });

--- a/src/logic/collision.ts
+++ b/src/logic/collision.ts
@@ -1,8 +1,10 @@
 // NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
 // Circle-circle collision using squared distance. No Math.sqrt.
 import type { Bullet } from './player';
-import type { Driftling } from './enemies';
-import { DRIFTLING_HIT_RADIUS } from './enemies';
+import type { Driftling, Husk } from './enemies';
+import { DRIFTLING_HIT_RADIUS, HUSK_HIT_RADIUS } from './enemies';
+import type { Wreck } from './wreck';
+import { WRECK_HIT_RADIUS } from './wreck';
 
 export const BULLET_HIT_RADIUS = 4;
 
@@ -45,6 +47,50 @@ export function playerEnemyHits(
     if (!enemy.alive) continue;
     if (circlesOverlap(player.x, player.y, player.radius, enemy.x, enemy.y, DRIFTLING_HIT_RADIUS)) {
       ids.push(enemy.id);
+    }
+  }
+  return ids;
+}
+
+export function bulletHuskHits(
+  bullets: Bullet[],
+  husks: Husk[],
+): { bulletIndex: number; huskId: number }[] {
+  const hits: { bulletIndex: number; huskId: number }[] = [];
+  for (let bi = 0; bi < bullets.length; bi++) {
+    for (const husk of husks) {
+      if (!husk.alive) continue;
+      if (circlesOverlap(bullets[bi].x, bullets[bi].y, BULLET_HIT_RADIUS, husk.x, husk.y, HUSK_HIT_RADIUS)) {
+        hits.push({ bulletIndex: bi, huskId: husk.id });
+      }
+    }
+  }
+  return hits;
+}
+
+export function playerHuskHits(
+  player: { x: number; y: number; radius: number },
+  husks: Husk[],
+): number[] {
+  const ids: number[] = [];
+  for (const husk of husks) {
+    if (!husk.alive) continue;
+    if (circlesOverlap(player.x, player.y, player.radius, husk.x, husk.y, HUSK_HIT_RADIUS)) {
+      ids.push(husk.id);
+    }
+  }
+  return ids;
+}
+
+export function playerWreckHits(
+  player: { x: number; y: number; radius: number },
+  wrecks: Wreck[],
+): number[] {
+  const ids: number[] = [];
+  for (const wreck of wrecks) {
+    if (!wreck.alive || wreck.phase !== 'settled') continue;
+    if (circlesOverlap(player.x, player.y, player.radius, wreck.x, wreck.y, WRECK_HIT_RADIUS)) {
+      ids.push(wreck.id);
     }
   }
   return ids;

--- a/src/logic/enemies.test.ts
+++ b/src/logic/enemies.test.ts
@@ -1,4 +1,4 @@
-import { updateDriftlings, Driftling } from './enemies';
+import { updateDriftlings, Driftling, updateHusks, Husk } from './enemies';
 
 function makeDriftling(overrides: Partial<Driftling> = {}): Driftling {
   return {
@@ -15,6 +15,37 @@ function makeDriftling(overrides: Partial<Driftling> = {}): Driftling {
     ...overrides,
   };
 }
+
+function makeHusk(overrides: Partial<Husk> = {}): Husk {
+  return { id: 1, x: 640, y: 100, hp: 4, alive: true, spawnedAtMs: 0, ...overrides };
+}
+
+describe('updateHusks -- vertical descent', () => {
+  it('descends at 50 px/s', () => {
+    const h = makeHusk({ y: 200 });
+    const result = updateHusks([h], 100);
+    expect(result[0].y).toBeCloseTo(205, 5); // 50 * 0.1 = 5px
+  });
+});
+
+describe('updateHusks -- lifecycle filtering', () => {
+  it('removes husks with alive=false', () => {
+    expect(updateHusks([makeHusk({ alive: false })], 16)).toHaveLength(0);
+  });
+
+  it('keeps alive husks', () => {
+    expect(updateHusks([makeHusk({ alive: true })], 16)).toHaveLength(1);
+  });
+
+  it('removes husks that descend past y=740', () => {
+    // y=735, 50px/s over 200ms = 10px -> ends at 745, removed
+    expect(updateHusks([makeHusk({ y: 735 })], 200)).toHaveLength(0);
+  });
+
+  it('keeps husks still on screen', () => {
+    expect(updateHusks([makeHusk({ y: 200 })], 100)).toHaveLength(1);
+  });
+});
 
 describe('updateDriftlings -- determinism', () => {
   it('same inputs produce identical output', () => {

--- a/src/logic/enemies.ts
+++ b/src/logic/enemies.ts
@@ -3,6 +3,9 @@
 export const DRIFTLING_HIT_RADIUS = 14;
 const DESCENT_SPEED = 80; // px/s
 
+export const HUSK_HIT_RADIUS = 24;
+const HUSK_DESCENT_SPEED = 50; // px/s
+
 export interface Driftling {
   id: number;
   x: number;
@@ -14,6 +17,23 @@ export interface Driftling {
   spawnedAtMs: number;
   hp: number;
   alive: boolean;
+}
+
+export interface Husk {
+  id: number;
+  x: number;
+  y: number;
+  hp: number;
+  alive: boolean;
+  spawnedAtMs: number;
+}
+
+export function updateHusks(husks: Husk[], deltaMs: number): Husk[] {
+  const dt = deltaMs / 1000;
+  return husks
+    .filter((h) => h.alive)
+    .map((h) => ({ ...h, y: h.y + HUSK_DESCENT_SPEED * dt }))
+    .filter((h) => h.y <= 740);
 }
 
 export function updateDriftlings(

--- a/src/logic/player.ts
+++ b/src/logic/player.ts
@@ -34,9 +34,9 @@ export function createPlayer(): PlayerState {
   return { x: 640, y: 630, vx: 0, vy: 0, hp: 3, fireTimer: 0, bullets: [], invulnerabilityEndMs: 0 };
 }
 
-export function damagePlayer(state: PlayerState, timestamp: number): PlayerState {
+export function damagePlayer(state: PlayerState, timestamp: number, damage = 1): PlayerState {
   if (timestamp < state.invulnerabilityEndMs) return state;
-  return { ...state, hp: state.hp - 1, invulnerabilityEndMs: timestamp + INVULNERABILITY_MS };
+  return { ...state, hp: state.hp - damage, invulnerabilityEndMs: timestamp + INVULNERABILITY_MS };
 }
 
 export function updatePlayer(

--- a/src/logic/probe.test.ts
+++ b/src/logic/probe.test.ts
@@ -13,6 +13,8 @@ import {
   TARGETING_COOLDOWN_TIMEOUT_MS,
 } from './probe';
 import type { InputState } from '../systems/input';
+import { spawnWreck } from './wreck';
+import type { Wreck } from './wreck';
 
 const IDLE_INPUT: InputState = {
   moveX: 0, moveY: 0, reticleX: 0, reticleY: 0, fire: false, probe: false, cancelProbe: false, pause: false, dash: false,
@@ -34,6 +36,7 @@ function step(
     reticleX?: number;
     reticleY?: number;
     probeJustPressed?: boolean;
+    wrecks?: Wreck[];
   } = {},
 ): ProbeState {
   return updateProbe(
@@ -46,6 +49,7 @@ function step(
     opts.reticleX ?? 640,
     opts.reticleY ?? 200,
     opts.probeJustPressed ?? false,
+    opts.wrecks ?? [],
   );
 }
 
@@ -62,6 +66,8 @@ describe('createProbe', () => {
     expect(p.cooldownTotalMs).toBe(0);
     expect(p.rewardFlashEndMs).toBe(0);
     expect(p.targetingCooldownEndMs).toBe(0);
+    expect(p.candidateWreckId).toBeNull();
+    expect(p.targetWreckId).toBeNull();
   });
 });
 
@@ -242,6 +248,133 @@ describe('probeTakeHit', () => {
     const after = probeTakeHit(lowHp, 500);
     expect(after.status).toBe('DESTROYED');
     expect(after.cooldownEndMs).toBe(500 + COOLDOWN_DESTROYED_MS);
+  });
+});
+
+describe('TARGETING -- wreck candidate detection', () => {
+  const targeting: ProbeState = { ...createProbe(), status: 'TARGETING', targetingStartMs: 0 };
+
+  it('sets candidateWreckId when settled wreck is within 30px of reticle', () => {
+    const wreck = spawnWreck(42, 640, 200, 0); // reticle default is (640, 200)
+    const after = step(targeting, { wrecks: [wreck] });
+    expect(after.candidateWreckId).toBe(42);
+  });
+
+  it('leaves candidateWreckId null when wreck is beyond 30px', () => {
+    const wreck = spawnWreck(1, 640, 300, 0); // 100px below default reticle (640, 200)
+    const after = step(targeting, { wrecks: [wreck] });
+    expect(after.candidateWreckId).toBeNull();
+  });
+
+  it('leaves candidateWreckId null when wreck is in falling phase', () => {
+    const wreck: Wreck = { ...spawnWreck(1, 640, 200, 0), phase: 'falling' };
+    const after = step(targeting, { wrecks: [wreck] });
+    expect(after.candidateWreckId).toBeNull();
+  });
+
+  it('picks the nearest wreck when multiple are within range', () => {
+    const close = spawnWreck(10, 641, 200, 0); // 1px away
+    const far = spawnWreck(20, 650, 200, 0);   // 10px away
+    const after = step(targeting, { wrecks: [far, close] });
+    expect(after.candidateWreckId).toBe(10);
+  });
+
+  it('when launched with a candidate, sets targetX/Y to wreck position and emptyReturn=false', () => {
+    const wreck = spawnWreck(5, 640, 200, 0);
+    const after = step(targeting, { probeJustPressed: true, wrecks: [wreck] });
+    expect(after.status).toBe('LAUNCHED');
+    expect(after.targetX).toBe(640);
+    expect(after.targetY).toBe(200);
+    expect(after.targetWreckId).toBe(5);
+    expect(after.emptyReturn).toBe(false);
+  });
+
+  it('when launched with no candidate, flies to reticle with emptyReturn=true', () => {
+    const after = step(targeting, { probeJustPressed: true, reticleX: 800, reticleY: 300 });
+    expect(after.status).toBe('LAUNCHED');
+    expect(after.targetX).toBe(800);
+    expect(after.targetY).toBe(300);
+    expect(after.targetWreckId).toBeNull();
+    expect(after.emptyReturn).toBe(true);
+  });
+});
+
+describe('LAUNCHED -- wreck arrival', () => {
+  function launchedAtWreck(wreckId: number): ProbeState {
+    return {
+      ...createProbe(),
+      status: 'LAUNCHED',
+      x: 640,
+      y: 630,
+      targetX: 648,
+      targetY: 630,
+      targetWreckId: wreckId,
+      emptyReturn: false,
+    };
+  }
+
+  it('transitions to TETHERED on arrival when target wreck is still settled', () => {
+    const wreck = spawnWreck(7, 648, 630, 0);
+    const after = step(launchedAtWreck(7), { deltaMs: 16, timestamp: 100, wrecks: [wreck] });
+    expect(after.status).toBe('TETHERED');
+    expect(after.tetheredSinceMs).toBe(100);
+  });
+
+  it('transitions to DESTROYED on arrival when target wreck has gone falling', () => {
+    const wreck: Wreck = { ...spawnWreck(7, 648, 630, 0), phase: 'falling' };
+    const after = step(launchedAtWreck(7), { deltaMs: 16, wrecks: [wreck] });
+    expect(after.status).toBe('DESTROYED');
+    expect(after.targetWreckId).toBeNull();
+  });
+
+  it('transitions to DESTROYED on arrival when target wreck no longer exists', () => {
+    const after = step(launchedAtWreck(7), { deltaMs: 16, wrecks: [] });
+    expect(after.status).toBe('DESTROYED');
+  });
+});
+
+describe('TETHERED -- salvage and wreck-falls', () => {
+  function tethered(wreckId: number, tetheredSinceMs: number): ProbeState {
+    return { ...createProbe(), status: 'TETHERED', targetWreckId: wreckId, tetheredSinceMs };
+  }
+
+  it('returns to RETURNING with tier 1 on short hold (< 1000ms)', () => {
+    const wreck = spawnWreck(3, 400, 300, 0);
+    const after = step(tethered(3, 0), { probeJustPressed: true, timestamp: 500, wrecks: [wreck] });
+    expect(after.status).toBe('RETURNING');
+    expect(after.rewardTier).toBe(1);
+    expect(after.emptyReturn).toBe(false);
+    expect(after.targetWreckId).toBeNull();
+  });
+
+  it('returns tier 2 for hold 1000ms to 2499ms', () => {
+    const wreck = spawnWreck(3, 400, 300, 0);
+    const after = step(tethered(3, 0), { probeJustPressed: true, timestamp: 1500, wrecks: [wreck] });
+    expect(after.rewardTier).toBe(2);
+  });
+
+  it('returns tier 3 for hold >= 2500ms', () => {
+    const wreck = spawnWreck(3, 400, 300, 0);
+    const after = step(tethered(3, 0), { probeJustPressed: true, timestamp: 3000, wrecks: [wreck] });
+    expect(after.rewardTier).toBe(3);
+  });
+
+  it('enters DESTROYED when tethered wreck transitions to falling', () => {
+    const wreck: Wreck = { ...spawnWreck(3, 400, 300, 0), phase: 'falling' };
+    const after = step(tethered(3, 0), { wrecks: [wreck] });
+    expect(after.status).toBe('DESTROYED');
+    expect(after.targetWreckId).toBeNull();
+  });
+
+  it('enters DESTROYED when tethered wreck no longer exists', () => {
+    const after = step(tethered(3, 0), { wrecks: [] });
+    expect(after.status).toBe('DESTROYED');
+  });
+
+  it('stays TETHERED when not pressing probe button and wreck is still settled', () => {
+    const wreck = spawnWreck(3, 400, 300, 0);
+    const after = step(tethered(3, 0), { wrecks: [wreck] });
+    expect(after.status).toBe('TETHERED');
   });
 });
 

--- a/src/logic/probe.ts
+++ b/src/logic/probe.ts
@@ -1,5 +1,7 @@
 // NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
 import type { InputState } from '../systems/input';
+import type { Wreck } from './wreck';
+import { salvageTier } from './wreck';
 
 const PROBE_TRAVEL_SPEED = 600;
 export const PROBE_HP = 3;
@@ -11,6 +13,7 @@ export const TARGETING_COOLDOWN_CANCEL_MS = 1500;
 export const TARGETING_COOLDOWN_TIMEOUT_MS = 3000;
 const CANVAS_WIDTH = 1280;
 const CANVAS_HEIGHT = 720;
+const RETICLE_LOCK_RADIUS = 30; // px: reticle must be within this distance to lock onto a settled wreck
 
 export type ProbeStatus =
   | 'IDLE'
@@ -37,6 +40,8 @@ export interface ProbeState {
   emptyReturn: boolean;
   targetingStartMs: number;
   targetingCooldownEndMs: number;
+  candidateWreckId: number | null;
+  targetWreckId: number | null;
 }
 
 export interface ReticleState {
@@ -60,6 +65,8 @@ export function createProbe(): ProbeState {
     emptyReturn: false,
     targetingStartMs: 0,
     targetingCooldownEndMs: 0,
+    candidateWreckId: null,
+    targetWreckId: null,
   };
 }
 
@@ -103,6 +110,7 @@ export function updateProbe(
   reticleX: number,
   reticleY: number,
   probeJustPressed: boolean,
+  wrecks: Wreck[],
 ): ProbeState {
   const dt = deltaMs / 1000;
 
@@ -115,24 +123,53 @@ export function updateProbe(
     }
 
     case 'TARGETING': {
+      // Scan for nearest settled wreck within reticle lock radius
+      let candidateWreckId: number | null = null;
+      let minDist2 = RETICLE_LOCK_RADIUS * RETICLE_LOCK_RADIUS;
+      for (const w of wrecks) {
+        if (!w.alive || w.phase !== 'settled') continue;
+        const dx = reticleX - w.x;
+        const dy = reticleY - w.y;
+        const dist2 = dx * dx + dy * dy;
+        if (dist2 < minDist2) {
+          minDist2 = dist2;
+          candidateWreckId = w.id;
+        }
+      }
+
       if (timestamp - probe.targetingStartMs >= TARGETING_MAX_MS) {
-        return { ...probe, status: 'TARGETING_COOLDOWN', targetingCooldownEndMs: timestamp + TARGETING_COOLDOWN_TIMEOUT_MS };
+        return {
+          ...probe,
+          candidateWreckId: null,
+          status: 'TARGETING_COOLDOWN',
+          targetingCooldownEndMs: timestamp + TARGETING_COOLDOWN_TIMEOUT_MS,
+        };
       }
       if (input.cancelProbe) {
-        return { ...probe, status: 'TARGETING_COOLDOWN', targetingCooldownEndMs: timestamp + TARGETING_COOLDOWN_CANCEL_MS };
+        return {
+          ...probe,
+          candidateWreckId: null,
+          status: 'TARGETING_COOLDOWN',
+          targetingCooldownEndMs: timestamp + TARGETING_COOLDOWN_CANCEL_MS,
+        };
       }
       if (probeJustPressed) {
+        const targetWreck = candidateWreckId !== null ? (wrecks.find((w) => w.id === candidateWreckId) ?? null) : null;
+        const targetX = targetWreck ? targetWreck.x : reticleX;
+        const targetY = targetWreck ? targetWreck.y : reticleY;
         return {
           ...probe,
           status: 'LAUNCHED',
           x: playerX,
           y: playerY,
-          targetX: reticleX,
-          targetY: reticleY,
-          emptyReturn: true,
+          targetX,
+          targetY,
+          targetWreckId: candidateWreckId,
+          candidateWreckId: null,
+          emptyReturn: candidateWreckId === null,
         };
       }
-      return probe;
+      return { ...probe, candidateWreckId };
     }
 
     case 'TARGETING_COOLDOWN': {
@@ -148,21 +185,28 @@ export function updateProbe(
       const distToTarget = Math.sqrt(dx * dx + dy * dy);
       const moveDistance = PROBE_TRAVEL_SPEED * dt;
       if (distToTarget === 0 || moveDistance >= distToTarget) {
-        return {
-          ...probe,
-          x: probe.targetX,
-          y: probe.targetY,
-          status: 'RETURNING',
-          emptyReturn: true,
-        };
+        if (probe.targetWreckId !== null) {
+          const targetWreck = wrecks.find((w) => w.id === probe.targetWreckId) ?? null;
+          if (!targetWreck || targetWreck.phase !== 'settled') {
+            return { ...probe, x: probe.targetX, y: probe.targetY, status: 'DESTROYED', targetWreckId: null };
+          }
+          return { ...probe, x: probe.targetX, y: probe.targetY, status: 'TETHERED', tetheredSinceMs: timestamp };
+        }
+        return { ...probe, x: probe.targetX, y: probe.targetY, status: 'RETURNING', emptyReturn: true };
       }
       const ratio = moveDistance / distToTarget;
       return { ...probe, x: probe.x + dx * ratio, y: probe.y + dy * ratio };
     }
 
     case 'TETHERED': {
+      const tetheredWreck = wrecks.find((w) => w.id === probe.targetWreckId) ?? null;
+      if (!tetheredWreck || tetheredWreck.phase !== 'settled') {
+        return { ...probe, status: 'DESTROYED', targetWreckId: null };
+      }
       if (probeJustPressed) {
-        return { ...probe, status: 'RETURNING', rewardTier: 1, emptyReturn: false };
+        const holdMs = timestamp - probe.tetheredSinceMs;
+        const tier = salvageTier(holdMs);
+        return { ...probe, status: 'RETURNING', rewardTier: tier, emptyReturn: false, targetWreckId: null };
       }
       return probe;
     }

--- a/src/logic/run.ts
+++ b/src/logic/run.ts
@@ -1,0 +1,9 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+
+export interface RunState {
+  salvageCount: number;
+}
+
+export function createRunState(): RunState {
+  return { salvageCount: 0 };
+}

--- a/src/logic/spawner.test.ts
+++ b/src/logic/spawner.test.ts
@@ -1,20 +1,23 @@
 import { createSpawner, updateSpawner, SpawnerState } from './spawner';
 import { createRng } from './rng';
+import type { Husk } from './enemies';
 
 function advanceToTime(
   state: SpawnerState,
   targetMs: number,
   stepMs = 100,
-): { state: SpawnerState; allSpawned: ReturnType<typeof updateSpawner>['spawned'] } {
+): { state: SpawnerState; allSpawned: ReturnType<typeof updateSpawner>['spawned']; allHusks: Husk[] } {
   const rng = createRng('test-seed');
   let current = state;
   const allSpawned: ReturnType<typeof updateSpawner>['spawned'] = [];
+  const allHusks: Husk[] = [];
   for (let t = 0; t <= targetMs; t += stepMs) {
     const result = updateSpawner(current, rng, t);
     current = result.state;
     allSpawned.push(...result.spawned);
+    allHusks.push(...result.spawnedHusks);
   }
-  return { state: current, allSpawned };
+  return { state: current, allSpawned, allHusks };
 }
 
 describe('spawner -- determinism', () => {
@@ -130,10 +133,12 @@ describe('spawner -- amplitude constraint', () => {
 });
 
 describe('spawner -- monotonic ids', () => {
-  it('each spawned driftling has a unique monotonically increasing id', () => {
-    const { allSpawned } = advanceToTime(createSpawner(), 30000);
-    for (let i = 0; i < allSpawned.length; i++) {
-      expect(allSpawned[i].id).toBe(i);
+  it('all spawned entities (driftlings + husks) have unique monotonically increasing ids', () => {
+    const { allSpawned, allHusks } = advanceToTime(createSpawner(), 45000);
+    // Collect all ids from both entity types sorted by id value
+    const allIds = [...allSpawned.map((d) => d.id), ...allHusks.map((h) => h.id)].sort((a, b) => a - b);
+    for (let i = 0; i < allIds.length; i++) {
+      expect(allIds[i]).toBe(i);
     }
   });
 });
@@ -151,6 +156,65 @@ describe('spawner -- spawn position', () => {
     for (const d of allSpawned) {
       expect(d.spawnX).toBeGreaterThanOrEqual(100);
       expect(d.spawnX).toBeLessThanOrEqual(1180);
+    }
+  });
+});
+
+describe('spawner -- husk schedule', () => {
+  it('produces no husks before 20000ms', () => {
+    const { allHusks } = advanceToTime(createSpawner(), 19999);
+    expect(allHusks).toHaveLength(0);
+  });
+
+  it('first husk spawns at 20000ms', () => {
+    const rng = createRng('husk-timing-seed');
+    let state = createSpawner();
+    for (let t = 0; t < 20000; t += 100) {
+      const r = updateSpawner(state, rng, t);
+      state = r.state;
+    }
+    const result = updateSpawner(state, rng, 20000);
+    expect(result.spawnedHusks).toHaveLength(1);
+  });
+
+  it('husks spawn every 4000ms after first spawn', () => {
+    const { allHusks } = advanceToTime(createSpawner(), 45000);
+    // From 20000ms to 44000ms in 4000ms steps: 7 husks (20k, 24k, 28k, 32k, 36k, 40k, 44k)
+    expect(allHusks).toHaveLength(7);
+  });
+
+  it('produces no husks at or after 45000ms', () => {
+    const rng = createRng('husk-stop-seed');
+    let state = createSpawner();
+    for (let t = 0; t < 45000; t += 100) {
+      const r = updateSpawner(state, rng, t);
+      state = r.state;
+    }
+    for (let t = 45000; t <= 50000; t += 100) {
+      const result = updateSpawner(state, rng, t);
+      expect(result.spawnedHusks).toHaveLength(0);
+    }
+  });
+
+  it('all husks spawn with x within [100, 1180]', () => {
+    const { allHusks } = advanceToTime(createSpawner(), 45000);
+    for (const h of allHusks) {
+      expect(h.x).toBeGreaterThanOrEqual(100);
+      expect(h.x).toBeLessThanOrEqual(1180);
+    }
+  });
+
+  it('all husks spawn at y=-20', () => {
+    const { allHusks } = advanceToTime(createSpawner(), 45000);
+    for (const h of allHusks) {
+      expect(h.y).toBe(-20);
+    }
+  });
+
+  it('all husks spawn with hp=4', () => {
+    const { allHusks } = advanceToTime(createSpawner(), 45000);
+    for (const h of allHusks) {
+      expect(h.hp).toBe(4);
     }
   });
 });

--- a/src/logic/spawner.ts
+++ b/src/logic/spawner.ts
@@ -1,12 +1,18 @@
 // NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
 import type { Rng } from './rng';
 import type { Driftling } from './enemies';
+import type { Husk } from './enemies';
 
 const SPAWN_DELAY_MS = 5000;
 const SPAWN_STOP_MS = 45000;
 const INTERVAL_EARLY_MS = 1500; // 5s to 25s
 const INTERVAL_LATE_MS = 800;   // 25s to 45s
 const LATE_PHASE_MS = 25000;
+
+const HUSK_SPAWN_INTERVAL_MS = 4000;
+const HUSK_SPAWN_START_MS = 20000;
+const HUSK_SPAWN_STOP_MS = 45000;
+const HUSK_HP = 4;
 
 const SPAWN_X_MIN = 100;
 const SPAWN_X_MAX = 1180;
@@ -21,46 +27,65 @@ const SPAWN_Y = -20;
 export interface SpawnerState {
   nextSpawnAtMs: number;
   nextId: number;
+  nextHuskSpawnAtMs: number;
 }
 
 export function createSpawner(): SpawnerState {
-  return { nextSpawnAtMs: SPAWN_DELAY_MS, nextId: 0 };
+  return { nextSpawnAtMs: SPAWN_DELAY_MS, nextId: 0, nextHuskSpawnAtMs: HUSK_SPAWN_START_MS };
 }
 
 export function updateSpawner(
   state: SpawnerState,
   rng: Rng,
   currentTimeMs: number,
-): { state: SpawnerState; spawned: Driftling[] } {
-  if (currentTimeMs < state.nextSpawnAtMs || currentTimeMs >= SPAWN_STOP_MS) {
-    return { state, spawned: [] };
+): { state: SpawnerState; spawned: Driftling[]; spawnedHusks: Husk[] } {
+  let newState = state;
+  const spawned: Driftling[] = [];
+  const spawnedHusks: Husk[] = [];
+
+  if (currentTimeMs >= newState.nextSpawnAtMs && currentTimeMs < SPAWN_STOP_MS) {
+    const spawnX = rng.nextInt(SPAWN_X_MIN, SPAWN_X_MAX);
+    const maxLeft = spawnX - AMPLITUDE_EDGE_MARGIN;
+    const maxRight = AMPLITUDE_CANVAS_EDGE - spawnX;
+    const maxAllowed = Math.min(maxLeft, maxRight);
+    const amplitude = rng.nextFloat(AMPLITUDE_MIN, Math.min(AMPLITUDE_MAX, maxAllowed));
+    const frequency = rng.nextFloat(FREQUENCY_MIN, FREQUENCY_MAX);
+    const phase = rng.nextFloat(0, 2 * Math.PI);
+
+    const driftling: Driftling = {
+      id: newState.nextId,
+      x: spawnX,
+      y: SPAWN_Y,
+      spawnX,
+      amplitude,
+      frequency,
+      phase,
+      spawnedAtMs: currentTimeMs,
+      hp: 1,
+      alive: true,
+    };
+    spawned.push(driftling);
+    const interval = currentTimeMs >= LATE_PHASE_MS ? INTERVAL_LATE_MS : INTERVAL_EARLY_MS;
+    newState = { ...newState, nextSpawnAtMs: newState.nextSpawnAtMs + interval, nextId: newState.nextId + 1 };
   }
 
-  const spawnX = rng.nextInt(SPAWN_X_MIN, SPAWN_X_MAX);
-  const maxLeft = spawnX - AMPLITUDE_EDGE_MARGIN;
-  const maxRight = AMPLITUDE_CANVAS_EDGE - spawnX;
-  const maxAllowed = Math.min(maxLeft, maxRight);
-  const amplitude = rng.nextFloat(AMPLITUDE_MIN, Math.min(AMPLITUDE_MAX, maxAllowed));
-  const frequency = rng.nextFloat(FREQUENCY_MIN, FREQUENCY_MAX);
-  const phase = rng.nextFloat(0, 2 * Math.PI);
+  if (currentTimeMs >= newState.nextHuskSpawnAtMs && currentTimeMs < HUSK_SPAWN_STOP_MS) {
+    const huskX = rng.nextInt(SPAWN_X_MIN, SPAWN_X_MAX);
+    const husk: Husk = {
+      id: newState.nextId,
+      x: huskX,
+      y: SPAWN_Y,
+      hp: HUSK_HP,
+      alive: true,
+      spawnedAtMs: currentTimeMs,
+    };
+    spawnedHusks.push(husk);
+    newState = {
+      ...newState,
+      nextHuskSpawnAtMs: newState.nextHuskSpawnAtMs + HUSK_SPAWN_INTERVAL_MS,
+      nextId: newState.nextId + 1,
+    };
+  }
 
-  const spawned: Driftling = {
-    id: state.nextId,
-    x: spawnX,
-    y: SPAWN_Y,
-    spawnX,
-    amplitude,
-    frequency,
-    phase,
-    spawnedAtMs: currentTimeMs,
-    hp: 1,
-    alive: true,
-  };
-
-  const interval = currentTimeMs >= LATE_PHASE_MS ? INTERVAL_LATE_MS : INTERVAL_EARLY_MS;
-
-  return {
-    state: { nextSpawnAtMs: state.nextSpawnAtMs + interval, nextId: state.nextId + 1 },
-    spawned: [spawned],
-  };
+  return { state: newState, spawned, spawnedHusks };
 }

--- a/src/logic/wreck.test.ts
+++ b/src/logic/wreck.test.ts
@@ -1,0 +1,104 @@
+import { spawnWreck, updateWrecks, salvageTier, Wreck } from './wreck';
+
+describe('salvageTier', () => {
+  it('returns 1 for hold < 1000ms', () => {
+    expect(salvageTier(0)).toBe(1);
+    expect(salvageTier(999)).toBe(1);
+  });
+
+  it('returns 2 for hold 1000ms to 2499ms', () => {
+    expect(salvageTier(1000)).toBe(2);
+    expect(salvageTier(2499)).toBe(2);
+  });
+
+  it('returns 3 for hold >= 2500ms', () => {
+    expect(salvageTier(2500)).toBe(3);
+    expect(salvageTier(5000)).toBe(3);
+  });
+});
+
+describe('updateWrecks -- settled phase', () => {
+  it('wreck stays settled before 4000ms elapses', () => {
+    const wreck = spawnWreck(1, 400, 300, 0);
+    const result = updateWrecks([wreck], 100, 3999, null);
+    expect(result).toHaveLength(1);
+    expect(result[0].phase).toBe('settled');
+  });
+
+  it('wreck transitions to falling at 4000ms', () => {
+    const wreck = spawnWreck(1, 400, 300, 0);
+    const result = updateWrecks([wreck], 100, 4000, null);
+    expect(result).toHaveLength(1);
+    expect(result[0].phase).toBe('falling');
+  });
+
+  it('settled wreck does not move vertically', () => {
+    const wreck = spawnWreck(1, 400, 300, 0);
+    const result = updateWrecks([wreck], 1000, 1000, null);
+    expect(result[0].y).toBe(300);
+  });
+});
+
+describe('updateWrecks -- timer pause while tethered', () => {
+  it('tethering slides settledAt forward by deltaMs each frame', () => {
+    const wreck = spawnWreck(1, 400, 300, 0);
+    const result = updateWrecks([wreck], 500, 500, 1);
+    expect(result[0].settledAt).toBe(500);
+  });
+
+  it('un-tethered wreck does not slide settledAt', () => {
+    const wreck = spawnWreck(1, 400, 300, 0);
+    const result = updateWrecks([wreck], 500, 500, null);
+    expect(result[0].settledAt).toBe(0);
+  });
+
+  it('tethered wreck stays settled past the un-tethered 4000ms deadline', () => {
+    // Tether for 2000ms: settledAt slides to ~2000, deadline becomes 6000ms
+    let wrecks = [spawnWreck(1, 400, 300, 0)];
+    for (let t = 100; t <= 2000; t += 100) {
+      wrecks = updateWrecks(wrecks, 100, t, 1);
+    }
+    expect(wrecks[0].settledAt).toBeCloseTo(2000, 0);
+    // At t=4000 (still 2000ms before the new 6000ms deadline) -- still settled
+    const midResult = updateWrecks(wrecks, 100, 4000, null);
+    expect(midResult[0].phase).toBe('settled');
+    // At t=6000 -- transitions to falling
+    const lateResult = updateWrecks(wrecks, 100, 6000, null);
+    expect(lateResult[0].phase).toBe('falling');
+  });
+});
+
+describe('updateWrecks -- falling phase', () => {
+  it('scale at 2000ms into falling is 0.5', () => {
+    // settledAt=0, fallingStartMs=4000, currentTime=6000 -> elapsed=2s, scale=1-2/4=0.5
+    const wreck: Wreck = { ...spawnWreck(1, 400, 300, 0), phase: 'falling' };
+    const result = updateWrecks([wreck], 16, 6000, null);
+    expect(result[0].scale).toBeCloseTo(0.5, 2);
+  });
+
+  it('vy accelerates at 40 px/s² during falling', () => {
+    const wreck: Wreck = { ...spawnWreck(1, 400, 300, 0), phase: 'falling', vy: 25 };
+    const result = updateWrecks([wreck], 1000, 5000, null); // dt=1s
+    expect(result[0].vy).toBeCloseTo(65, 1); // 25 + 40*1
+  });
+
+  it('falling wreck moves downward', () => {
+    const wreck: Wreck = { ...spawnWreck(1, 400, 300, 0), phase: 'falling' };
+    const result = updateWrecks([wreck], 100, 4100, null);
+    expect(result[0].y).toBeGreaterThan(300);
+  });
+
+  it('wreck is removed when scale reaches 0', () => {
+    // settledAt=0, fallingStartMs=4000, scale=0 at currentTime=8000
+    const wreck: Wreck = { ...spawnWreck(1, 400, 300, 0), phase: 'falling' };
+    const result = updateWrecks([wreck], 100, 8100, null);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('updateWrecks -- alive filter', () => {
+  it('removes wrecks with alive=false', () => {
+    const wreck: Wreck = { ...spawnWreck(1, 400, 300, 0), alive: false };
+    expect(updateWrecks([wreck], 16, 1000, null)).toHaveLength(0);
+  });
+});

--- a/src/logic/wreck.ts
+++ b/src/logic/wreck.ts
@@ -1,0 +1,68 @@
+// NO Phaser imports. NO DOM. NO Math.random(). NO Date.now(). Deterministic given inputs.
+
+export const WRECK_HIT_RADIUS = 16;
+
+const SETTLED_DURATION_MS = 4000;
+const FALLING_DURATION_MS = 4000;
+const FALLING_ACCELERATION = 40; // px/s²
+const HUSK_SPAWN_VY = 25; // 50% of Husk descent speed (50px/s)
+
+export interface Wreck {
+  id: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  phase: 'settled' | 'falling';
+  settledAt: number; // ms timestamp; slides forward while tethered to pause the timer
+  scale: number; // 1.0 to 0.0 during falling phase
+  alive: boolean;
+}
+
+export function spawnWreck(id: number, x: number, y: number, spawnTimeMs: number): Wreck {
+  return {
+    id,
+    x,
+    y,
+    vx: 0,
+    vy: HUSK_SPAWN_VY,
+    phase: 'settled',
+    settledAt: spawnTimeMs,
+    scale: 1.0,
+    alive: true,
+  };
+}
+
+export function salvageTier(holdMs: number): number {
+  if (holdMs < 1000) return 1;
+  if (holdMs < 2500) return 2;
+  return 3;
+}
+
+export function updateWrecks(
+  wrecks: Wreck[],
+  deltaMs: number,
+  currentTimeMs: number,
+  tetheredWreckId: number | null,
+): Wreck[] {
+  const dt = deltaMs / 1000;
+  return wrecks
+    .filter((w) => w.alive)
+    .map((w): Wreck => {
+      if (w.phase === 'settled') {
+        const settledAt = w.id === tetheredWreckId ? w.settledAt + deltaMs : w.settledAt;
+        if (currentTimeMs - settledAt >= SETTLED_DURATION_MS) {
+          return { ...w, settledAt, phase: 'falling' };
+        }
+        return { ...w, settledAt };
+      }
+      // falling phase
+      const fallingStartMs = w.settledAt + SETTLED_DURATION_MS;
+      const fallingElapsedSec = (currentTimeMs - fallingStartMs) / 1000;
+      const scale = Math.max(0, 1.0 - fallingElapsedSec / (FALLING_DURATION_MS / 1000));
+      const vy = w.vy + FALLING_ACCELERATION * dt;
+      const y = w.y + w.vy * dt;
+      return { ...w, vy, y, scale, alive: scale > 0 };
+    })
+    .filter((w) => w.alive);
+}

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -10,15 +10,19 @@ import {
   ReticleState,
   TARGETING_MAX_MS,
 } from '../logic/probe';
-import { updateDriftlings, Driftling } from '../logic/enemies';
+import { updateDriftlings, Driftling, Husk, updateHusks } from '../logic/enemies';
 import { createSpawner, updateSpawner, SpawnerState } from '../logic/spawner';
-import { bulletEnemyHits, playerEnemyHits } from '../logic/collision';
+import { bulletEnemyHits, playerEnemyHits, bulletHuskHits, playerHuskHits } from '../logic/collision';
+import { updateWrecks, spawnWreck } from '../logic/wreck';
+import type { Wreck } from '../logic/wreck';
+import { createRunState, RunState } from '../logic/run';
 import { createRng, Rng } from '../logic/rng';
 import { ASSETS } from '../config/assets';
 import { Player } from '../entities/Player';
 import { Bullets } from '../entities/Bullets';
 import { Probe as ProbeEntity } from '../entities/Probe';
 import { Enemy } from '../entities/Enemy';
+import { Wreck as WreckEntity } from '../entities/Wreck';
 
 const SLOWMO_FACTOR = 0.2;
 // TODO: vary by game state per tuning.md
@@ -32,19 +36,24 @@ export class GameScene extends Phaser.Scene {
   private reticleState!: ReticleState;
   private background!: Phaser.GameObjects.TileSprite;
   private scrollImages: Phaser.GameObjects.Image[] = [];
-  // Entity render layer -- creation order determines draw depth (probe < player < bullets < hud)
+  // Entity render layer -- creation order determines draw depth (back to front)
+  private wreckEntity!: WreckEntity;
+  private enemyEntity!: Enemy;
+  private bulletsEntity!: Bullets;
   private probeEntity!: ProbeEntity;
   private playerEntity!: Player;
-  private bulletsEntity!: Bullets;
   private driftlings: Driftling[] = [];
+  private husks: Husk[] = [];
+  private wrecks: Wreck[] = [];
   private spawnerState!: SpawnerState;
   private spawnerRng!: Rng;
-  private enemyEntity!: Enemy;
+  private runState!: RunState;
   private graphics!: Phaser.GameObjects.Graphics;
   private flashText!: Phaser.GameObjects.Text;
   private targetingTimerText!: Phaser.GameObjects.Text;
   private scanCooldownText!: Phaser.GameObjects.Text;
   private hpText!: Phaser.GameObjects.Text;
+  private salvageText!: Phaser.GameObjects.Text;
   private scrollY = 0;
   private currentScrollSpeed = SCROLL_SPEED;
   private effectiveDeltaMs = 0;
@@ -61,6 +70,7 @@ export class GameScene extends Phaser.Scene {
     this.playerState = createPlayer();
     this.probeState = createProbe();
     this.reticleState = createReticle();
+    this.runState = createRunState();
 
     if (ASSETS.backgroundMode === 'tile') {
       this.background = this.add.tileSprite(640, 360, 1280, 720, ASSETS.background);
@@ -75,10 +85,12 @@ export class GameScene extends Phaser.Scene {
     this.spawnerState = createSpawner();
     this.spawnerRng = createRng('run-seed-spawner');
 
-    this.probeEntity = new ProbeEntity(this);
+    // Draw order (back to front): wrecks, enemies, bullets, probe, player, HUD
+    this.wreckEntity = new WreckEntity(this);
     this.enemyEntity = new Enemy(this);
-    this.playerEntity = new Player(this);
     this.bulletsEntity = new Bullets(this);
+    this.probeEntity = new ProbeEntity(this);
+    this.playerEntity = new Player(this);
     this.graphics = this.add.graphics();
     this.flashText = this.add
       .text(640, 360, '', { fontSize: '32px', color: '#00ffff' })
@@ -94,6 +106,9 @@ export class GameScene extends Phaser.Scene {
       .setVisible(false);
     this.hpText = this.add
       .text(20, 680, 'HP: 3', { fontSize: '14px', fontFamily: 'monospace', color: '#ff4444' })
+      .setOrigin(0, 1);
+    this.salvageText = this.add
+      .text(20, 700, 'SALVAGE: 0', { fontSize: '14px', fontFamily: 'monospace', color: '#00ffaa' })
       .setOrigin(0, 1);
   }
 
@@ -122,6 +137,10 @@ export class GameScene extends Phaser.Scene {
     // Reticle always updates using raw delta (dedicated IJKL / right stick, not slow-mo affected)
     this.reticleState = updateReticle(this.reticleState, inputFrame.current, this.rawDeltaMs);
 
+    // Update wrecks before probe so probe arrival sees the current wreck phase
+    const tetheredWreckId = this.probeState.status === 'TETHERED' ? this.probeState.targetWreckId : null;
+    this.wrecks = updateWrecks(this.wrecks, effectiveDeltaMs, timestamp, tetheredWreckId);
+
     const probeJustPressed = inputFrame.justPressed.has(LogicalAction.PROBE);
     this.probeState = updateProbe(
       this.probeState,
@@ -133,6 +152,7 @@ export class GameScene extends Phaser.Scene {
       this.reticleState.x,
       this.reticleState.y,
       probeJustPressed,
+      this.wrecks,
     );
 
     // Snap reticle 60px above player when entering TARGETING
@@ -142,31 +162,70 @@ export class GameScene extends Phaser.Scene {
 
     this.setSlowMo(this.probeState.status === 'TARGETING');
 
-    const { state: newSpawner, spawned } = updateSpawner(this.spawnerState, this.spawnerRng, timestamp);
+    // Salvage credit: probe completed a wreck tether return
+    if (prevProbeStatus === 'RETURNING' && this.probeState.status === 'COOLDOWN' && !this.probeState.emptyReturn) {
+      this.runState = { ...this.runState, salvageCount: this.runState.salvageCount + this.probeState.rewardTier };
+    }
+
+    const { state: newSpawner, spawned, spawnedHusks } = updateSpawner(this.spawnerState, this.spawnerRng, timestamp);
     this.spawnerState = newSpawner;
     this.driftlings = [...this.driftlings, ...spawned];
+    this.husks = [...this.husks, ...spawnedHusks];
+
     this.driftlings = updateDriftlings(this.driftlings, effectiveDeltaMs, timestamp);
+    this.husks = updateHusks(this.husks, effectiveDeltaMs);
 
+    // Bullet hits
     const bHits = bulletEnemyHits(this.playerState.bullets, this.driftlings);
-    const pHits = playerEnemyHits(
-      { x: this.playerState.x, y: this.playerState.y, radius: PLAYER_HIT_RADIUS },
-      this.driftlings,
-    );
+    const bHuskHits = bulletHuskHits(this.playerState.bullets, this.husks);
 
-    const hitBulletIndices = new Set(bHits.map((h) => h.bulletIndex));
-    const hitByBullet = new Set(bHits.map((h) => h.enemyId));
+    const hitBulletIndices = new Set([
+      ...bHits.map((h) => h.bulletIndex),
+      ...bHuskHits.map((h) => h.bulletIndex),
+    ]);
     this.playerState = {
       ...this.playerState,
       bullets: this.playerState.bullets.filter((_, i) => !hitBulletIndices.has(i)),
     };
+
+    // Apply driftling damage
+    const hitByBullet = new Set(bHits.map((h) => h.enemyId));
     this.driftlings = this.driftlings.map((d) =>
       hitByBullet.has(d.id) ? { ...d, hp: d.hp - 1, alive: d.hp - 1 > 0 } : d,
     );
 
+    // Apply husk damage -- dead husks spawn wrecks
+    const hitHusksByBullet = new Set(bHuskHits.map((h) => h.huskId));
+    const newWrecks: Wreck[] = [];
+    this.husks = this.husks.map((h) => {
+      if (!hitHusksByBullet.has(h.id)) return h;
+      const newHp = h.hp - 1;
+      if (newHp <= 0) {
+        newWrecks.push(spawnWreck(h.id, h.x, h.y, timestamp));
+        return { ...h, hp: 0, alive: false };
+      }
+      return { ...h, hp: newHp };
+    });
+    this.wrecks = [...this.wrecks, ...newWrecks];
+
+    // Player-driftling collision
+    const pHits = playerEnemyHits(
+      { x: this.playerState.x, y: this.playerState.y, radius: PLAYER_HIT_RADIUS },
+      this.driftlings,
+    );
     if (pHits.length > 0) {
       this.playerState = damagePlayer(this.playerState, timestamp);
       const hitByPlayer = new Set(pHits);
       this.driftlings = this.driftlings.map((d) => (hitByPlayer.has(d.id) ? { ...d, alive: false } : d));
+    }
+
+    // Player-husk collision: 2 HP damage, husks survive contact
+    const pHuskHits = playerHuskHits(
+      { x: this.playerState.x, y: this.playerState.y, radius: PLAYER_HIT_RADIUS },
+      this.husks,
+    );
+    if (pHuskHits.length > 0) {
+      this.playerState = damagePlayer(this.playerState, timestamp, 2);
     }
   }
 
@@ -191,11 +250,12 @@ export class GameScene extends Phaser.Scene {
       }
     }
 
-    // Entity rendering -- each entity clears its own Graphics object
-    this.probeEntity.update(probe, reticle, ts, this.playerState.x, this.playerState.y);
-    this.enemyEntity.update(this.driftlings);
-    this.playerEntity.update(this.playerState);
+    // Entity rendering -- draw order matches creation order (back to front)
+    this.wreckEntity.update(this.wrecks, probe.candidateWreckId);
+    this.enemyEntity.update(this.driftlings, this.husks);
     this.bulletsEntity.update(this.playerState.bullets);
+    this.probeEntity.update(probe, reticle, ts, this.playerState.x, this.playerState.y);
+    this.playerEntity.update(this.playerState);
 
     // Countdown timer text (TARGETING) / scan cooldown text (TARGETING_COOLDOWN) -- HUD, stays here
     if (probe.status === 'TARGETING') {
@@ -223,6 +283,7 @@ export class GameScene extends Phaser.Scene {
     }
 
     this.hpText.setText(`HP: ${this.playerState.hp}`);
+    this.salvageText.setText(`SALVAGE: ${this.runState.salvageCount}`);
 
     // Reward flash text
     if (probe.rewardFlashEndMs > ts) {


### PR DESCRIPTION
## Summary

- Adds **Husks** as the second enemy type: 4 HP, 50 px/s descent, 40x40 gray rect, 24 px hit radius, 2 HP player damage on contact
- Adds **Wrecks**: spawn at Husk death position, 4s settled phase (probe-tetherable, timer pauses while tethered), 4s falling phase (shrinks to 0, accelerates off screen)
- Wires the **probe salvage loop**: TARGETING scans for settled wrecks within 30 px of reticle (soft lock via `candidateWreckId`), LAUNCHED carries hard lock (`targetWreckId`), TETHERED accumulates hold time and returns a tier (1/2/3) on release
- `RunState.salvageCount` increments by tier on each successful tether return; displayed in HUD as `SALVAGE: N`
- Fixes draw order: background → wrecks → enemies → bullets → probe → player → HUD
- `damagePlayer` gains optional `damage` param (default 1) for Husk 2 HP collision damage
- 157 tests passing, `tsc --noEmit` clean, `npm run build` exits 0

## New files

- `src/logic/wreck.ts` + `src/logic/wreck.test.ts`
- `src/logic/run.ts`

## Modified files

- `src/logic/enemies.ts` -- Husk entity
- `src/logic/enemies.test.ts` -- Husk tests
- `src/logic/spawner.ts` -- Husk schedule, updated return type
- `src/logic/spawner.test.ts` -- Husk timing tests
- `src/logic/collision.ts` -- bulletHuskHits, playerHuskHits, playerWreckHits
- `src/logic/collision.test.ts` -- new collision tests
- `src/logic/probe.ts` -- candidateWreckId/targetWreckId, TARGETING scan, TETHERED salvage
- `src/logic/probe.test.ts` -- wreck candidate/lock/tether tests
- `src/logic/player.ts` -- damagePlayer damage param
- `src/entities/Enemy.ts` -- renders Husks
- `src/entities/Wreck.ts` -- full implementation (was stub)
- `src/scenes/GameScene.ts` -- full wiring

Closes #75