### PR TITLE
refactor: rename wreck 'settled' phase to 'drifting'

### DIFF
--- a/src/logic/collision.test.ts
+++ b/src/logic/collision.test.ts
@@ -128,8 +128,8 @@ function makeHusk(id: number, x: number, y: number, alive = true): Husk {
   return { id, x, y, hp: 4, alive, spawnedAtMs: 0 };
 }
 
-function makeWreck(id: number, x: number, y: number, phase: 'settled' | 'falling' = 'settled', alive = true): Wreck {
-  return { id, x, y, vx: 0, vy: 25, phase, settledAt: 0, scale: 1.0, alive };
+function makeWreck(id: number, x: number, y: number, phase: 'drifting' | 'falling' = 'drifting', alive = true): Wreck {
+  return { id, x, y, vx: 0, vy: 25, phase, driftingAt: 0, scale: 1.0, alive };
 }
 
 const COMBINED_BULLET_HUSK = BULLET_HIT_RADIUS + HUSK_HIT_RADIUS; // 28
@@ -193,11 +193,11 @@ describe('playerHuskHits', () => {
 describe('playerWreckHits', () => {
   const player = { x: 640, y: 600, radius: 16 };
 
-  it('returns wreck id when player overlaps settled wreck', () => {
+  it('returns wreck id when player overlaps drifting wreck', () => {
     expect(playerWreckHits(player, [makeWreck(3, 640, 600)])).toEqual([3]);
   });
 
-  it('returns hit within combined radius for settled wreck', () => {
+  it('returns hit within combined radius for drifting wreck', () => {
     expect(playerWreckHits(player, [makeWreck(1, 640 + COMBINED_PLAYER_WRECK - 1, 600)])).toHaveLength(1);
   });
 
@@ -210,7 +210,7 @@ describe('playerWreckHits', () => {
   });
 
   it('skips wrecks with alive=false', () => {
-    expect(playerWreckHits(player, [makeWreck(1, 640, 600, 'settled', false)])).toHaveLength(0);
+    expect(playerWreckHits(player, [makeWreck(1, 640, 600, 'drifting', false)])).toHaveLength(0);
   });
 
   it('returns empty when wrecks is empty', () => {

--- a/src/logic/collision.ts
+++ b/src/logic/collision.ts
@@ -88,7 +88,7 @@ export function playerWreckHits(
 ): number[] {
   const ids: number[] = [];
   for (const wreck of wrecks) {
-    if (!wreck.alive || wreck.phase !== 'settled') continue;
+    if (!wreck.alive || wreck.phase !== 'drifting') continue;
     if (circlesOverlap(player.x, player.y, player.radius, wreck.x, wreck.y, WRECK_HIT_RADIUS)) {
       ids.push(wreck.id);
     }

--- a/src/logic/probe.test.ts
+++ b/src/logic/probe.test.ts
@@ -254,7 +254,7 @@ describe('probeTakeHit', () => {
 describe('TARGETING -- wreck candidate detection', () => {
   const targeting: ProbeState = { ...createProbe(), status: 'TARGETING', targetingStartMs: 0 };
 
-  it('sets candidateWreckId when settled wreck is within 30px of reticle', () => {
+  it('sets candidateWreckId when drifting wreck is within 30px of reticle', () => {
     const wreck = spawnWreck(42, 640, 200, 0); // reticle default is (640, 200)
     const after = step(targeting, { wrecks: [wreck] });
     expect(after.candidateWreckId).toBe(42);
@@ -313,7 +313,7 @@ describe('LAUNCHED -- wreck arrival', () => {
     };
   }
 
-  it('transitions to TETHERED on arrival when target wreck is still settled', () => {
+  it('transitions to TETHERED on arrival when target wreck is still drifting', () => {
     const wreck = spawnWreck(7, 648, 630, 0);
     const after = step(launchedAtWreck(7), { deltaMs: 16, timestamp: 100, wrecks: [wreck] });
     expect(after.status).toBe('TETHERED');
@@ -371,7 +371,7 @@ describe('TETHERED -- salvage and wreck-falls', () => {
     expect(after.status).toBe('DESTROYED');
   });
 
-  it('stays TETHERED when not pressing probe button and wreck is still settled', () => {
+  it('stays TETHERED when not pressing probe button and wreck is still drifting', () => {
     const wreck = spawnWreck(3, 400, 300, 0);
     const after = step(tethered(3, 0), { wrecks: [wreck] });
     expect(after.status).toBe('TETHERED');

--- a/src/logic/probe.ts
+++ b/src/logic/probe.ts
@@ -13,7 +13,7 @@ export const TARGETING_COOLDOWN_CANCEL_MS = 1500;
 export const TARGETING_COOLDOWN_TIMEOUT_MS = 3000;
 const CANVAS_WIDTH = 1280;
 const CANVAS_HEIGHT = 720;
-const RETICLE_LOCK_RADIUS = 30; // px: reticle must be within this distance to lock onto a settled wreck
+const RETICLE_LOCK_RADIUS = 30; // px: reticle must be within this distance to lock onto a drifting wreck
 
 export type ProbeStatus =
   | 'IDLE'
@@ -123,11 +123,11 @@ export function updateProbe(
     }
 
     case 'TARGETING': {
-      // Scan for nearest settled wreck within reticle lock radius
+      // Scan for nearest drifting wreck within reticle lock radius
       let candidateWreckId: number | null = null;
       let minDist2 = RETICLE_LOCK_RADIUS * RETICLE_LOCK_RADIUS;
       for (const w of wrecks) {
-        if (!w.alive || w.phase !== 'settled') continue;
+        if (!w.alive || w.phase !== 'drifting') continue;
         const dx = reticleX - w.x;
         const dy = reticleY - w.y;
         const dist2 = dx * dx + dy * dy;
@@ -187,7 +187,7 @@ export function updateProbe(
       if (distToTarget === 0 || moveDistance >= distToTarget) {
         if (probe.targetWreckId !== null) {
           const targetWreck = wrecks.find((w) => w.id === probe.targetWreckId) ?? null;
-          if (!targetWreck || targetWreck.phase !== 'settled') {
+          if (!targetWreck || targetWreck.phase !== 'drifting') {
             return { ...probe, x: probe.targetX, y: probe.targetY, status: 'DESTROYED', targetWreckId: null };
           }
           return { ...probe, x: probe.targetX, y: probe.targetY, status: 'TETHERED', tetheredSinceMs: timestamp };
@@ -200,7 +200,7 @@ export function updateProbe(
 
     case 'TETHERED': {
       const tetheredWreck = wrecks.find((w) => w.id === probe.targetWreckId) ?? null;
-      if (!tetheredWreck || tetheredWreck.phase !== 'settled') {
+      if (!tetheredWreck || tetheredWreck.phase !== 'drifting') {
         return { ...probe, status: 'DESTROYED', targetWreckId: null };
       }
       if (probeJustPressed) {

--- a/src/logic/wreck.test.ts
+++ b/src/logic/wreck.test.ts
@@ -17,12 +17,12 @@ describe('salvageTier', () => {
   });
 });
 
-describe('updateWrecks -- settled phase', () => {
-  it('wreck stays settled before 4000ms elapses', () => {
+describe('updateWrecks -- drifting phase', () => {
+  it('wreck stays drifting before 4000ms elapses', () => {
     const wreck = spawnWreck(1, 400, 300, 0);
     const result = updateWrecks([wreck], 100, 3999, null);
     expect(result).toHaveLength(1);
-    expect(result[0].phase).toBe('settled');
+    expect(result[0].phase).toBe('drifting');
   });
 
   it('wreck transitions to falling at 4000ms', () => {
@@ -32,7 +32,7 @@ describe('updateWrecks -- settled phase', () => {
     expect(result[0].phase).toBe('falling');
   });
 
-  it('settled wreck does not move vertically', () => {
+  it('wreck position is unchanged during drifting phase', () => {
     const wreck = spawnWreck(1, 400, 300, 0);
     const result = updateWrecks([wreck], 1000, 1000, null);
     expect(result[0].y).toBe(300);
@@ -40,28 +40,28 @@ describe('updateWrecks -- settled phase', () => {
 });
 
 describe('updateWrecks -- timer pause while tethered', () => {
-  it('tethering slides settledAt forward by deltaMs each frame', () => {
+  it('tethering slides driftingAt forward by deltaMs each frame', () => {
     const wreck = spawnWreck(1, 400, 300, 0);
     const result = updateWrecks([wreck], 500, 500, 1);
-    expect(result[0].settledAt).toBe(500);
+    expect(result[0].driftingAt).toBe(500);
   });
 
-  it('un-tethered wreck does not slide settledAt', () => {
+  it('un-tethered wreck does not slide driftingAt', () => {
     const wreck = spawnWreck(1, 400, 300, 0);
     const result = updateWrecks([wreck], 500, 500, null);
-    expect(result[0].settledAt).toBe(0);
+    expect(result[0].driftingAt).toBe(0);
   });
 
-  it('tethered wreck stays settled past the un-tethered 4000ms deadline', () => {
-    // Tether for 2000ms: settledAt slides to ~2000, deadline becomes 6000ms
+  it('tethered wreck stays drifting past the un-tethered 4000ms deadline', () => {
+    // Tether for 2000ms: driftingAt slides to ~2000, deadline becomes 6000ms
     let wrecks = [spawnWreck(1, 400, 300, 0)];
     for (let t = 100; t <= 2000; t += 100) {
       wrecks = updateWrecks(wrecks, 100, t, 1);
     }
-    expect(wrecks[0].settledAt).toBeCloseTo(2000, 0);
-    // At t=4000 (still 2000ms before the new 6000ms deadline) -- still settled
+    expect(wrecks[0].driftingAt).toBeCloseTo(2000, 0);
+    // At t=4000 (still 2000ms before the new 6000ms deadline) -- still drifting
     const midResult = updateWrecks(wrecks, 100, 4000, null);
-    expect(midResult[0].phase).toBe('settled');
+    expect(midResult[0].phase).toBe('drifting');
     // At t=6000 -- transitions to falling
     const lateResult = updateWrecks(wrecks, 100, 6000, null);
     expect(lateResult[0].phase).toBe('falling');
@@ -70,7 +70,7 @@ describe('updateWrecks -- timer pause while tethered', () => {
 
 describe('updateWrecks -- falling phase', () => {
   it('scale at 2000ms into falling is 0.5', () => {
-    // settledAt=0, fallingStartMs=4000, currentTime=6000 -> elapsed=2s, scale=1-2/4=0.5
+    // driftingAt=0, fallingStartMs=4000, currentTime=6000 -> elapsed=2s, scale=1-2/4=0.5
     const wreck: Wreck = { ...spawnWreck(1, 400, 300, 0), phase: 'falling' };
     const result = updateWrecks([wreck], 16, 6000, null);
     expect(result[0].scale).toBeCloseTo(0.5, 2);
@@ -89,7 +89,7 @@ describe('updateWrecks -- falling phase', () => {
   });
 
   it('wreck is removed when scale reaches 0', () => {
-    // settledAt=0, fallingStartMs=4000, scale=0 at currentTime=8000
+    // driftingAt=0, fallingStartMs=4000, scale=0 at currentTime=8000
     const wreck: Wreck = { ...spawnWreck(1, 400, 300, 0), phase: 'falling' };
     const result = updateWrecks([wreck], 100, 8100, null);
     expect(result).toHaveLength(0);

--- a/src/logic/wreck.ts
+++ b/src/logic/wreck.ts
@@ -2,7 +2,7 @@
 
 export const WRECK_HIT_RADIUS = 16;
 
-const SETTLED_DURATION_MS = 4000;
+const DRIFTING_DURATION_MS = 4000;
 const FALLING_DURATION_MS = 4000;
 const FALLING_ACCELERATION = 40; // px/s²
 const HUSK_SPAWN_VY = 25; // 50% of Husk descent speed (50px/s)
@@ -13,8 +13,8 @@ export interface Wreck {
   y: number;
   vx: number;
   vy: number;
-  phase: 'settled' | 'falling';
-  settledAt: number; // ms timestamp; slides forward while tethered to pause the timer
+  phase: 'drifting' | 'falling';
+  driftingAt: number; // ms timestamp; slides forward while tethered to pause the timer
   scale: number; // 1.0 to 0.0 during falling phase
   alive: boolean;
 }
@@ -26,8 +26,8 @@ export function spawnWreck(id: number, x: number, y: number, spawnTimeMs: number
     y,
     vx: 0,
     vy: HUSK_SPAWN_VY,
-    phase: 'settled',
-    settledAt: spawnTimeMs,
+    phase: 'drifting',
+    driftingAt: spawnTimeMs,
     scale: 1.0,
     alive: true,
   };
@@ -49,15 +49,15 @@ export function updateWrecks(
   return wrecks
     .filter((w) => w.alive)
     .map((w): Wreck => {
-      if (w.phase === 'settled') {
-        const settledAt = w.id === tetheredWreckId ? w.settledAt + deltaMs : w.settledAt;
-        if (currentTimeMs - settledAt >= SETTLED_DURATION_MS) {
-          return { ...w, settledAt, phase: 'falling' };
+      if (w.phase === 'drifting') {
+        const driftingAt = w.id === tetheredWreckId ? w.driftingAt + deltaMs : w.driftingAt;
+        if (currentTimeMs - driftingAt >= DRIFTING_DURATION_MS) {
+          return { ...w, driftingAt, phase: 'falling' };
         }
-        return { ...w, settledAt };
+        return { ...w, driftingAt };
       }
       // falling phase
-      const fallingStartMs = w.settledAt + SETTLED_DURATION_MS;
+      const fallingStartMs = w.driftingAt + DRIFTING_DURATION_MS;
       const fallingElapsedSec = (currentTimeMs - fallingStartMs) / 1000;
       const scale = Math.max(0, 1.0 - fallingElapsedSec / (FALLING_DURATION_MS / 1000));
       const vy = w.vy + FALLING_ACCELERATION * dt;


### PR DESCRIPTION
## Summary

- Renames the wreck phase `'settled'` to `'drifting'` across all logic files
- Renames `SETTLED_DURATION_MS` to `DRIFTING_DURATION_MS` and `settledAt` to `driftingAt` in the `Wreck` interface and all usages
- Updates all phase comparisons, test descriptions, and inline comments to match

No behavior change -- pure cosmetic rename for semantic clarity. 'Drifting' better describes a wreck floating in space before it falls; 'settled' implied it had landed on something.