### PR TITLE
docs: update deployment instructions for actual Netlify workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Retrofuturistic vertical shmup with tether-probe salvage mechanics. Phaser 3 + T
 
 ## Deployment
 
-Production deploys are manual and triggered via GitHub Actions. See [docs/deployment.md](docs/deployment.md) for instructions.
+Production deploys are intentional and manually published in the Netlify UI. See [docs/deployment.md](docs/deployment.md) for instructions.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,32 +1,46 @@
-# Deployment
+# Production Deployment
 
-## Why deploys are manual
+Production deploys are intentional and manually published. This prevents auto-deploy on every PR merge from burning Netlify credits.
 
-Netlify free tier is 300 credits/month. Each production deploy costs 15 credits. Auto-deploy on every merge burned half the monthly budget in a single day of rapid PR merges.
+## How it works
 
-Production deploys are now intentional and batched. Pushing to main does not deploy. The live site is updated only when a developer explicitly triggers a deploy.
+Netlify Auto Publishing is locked. PR merges to main still trigger builds (Netlify uploads the build), but the build is NOT published to the production URL automatically. The currently published deploy stays live until a developer manually publishes a newer deploy.
 
-## How to trigger a production deploy
+## How to publish a deploy
 
-1. Go to the GitHub Actions tab in the repository
-2. Select "Deploy to production" from the left sidebar
-3. Click "Run workflow"
-4. Type `DEPLOY` in the confirm field (must be exact -- uppercase, no spaces)
-5. Click "Run workflow"
+1. Go to the Netlify dashboard for the project (timely-sprinkles-900094)
+2. Click into Deploys (left sidebar)
+3. Find the latest deploy (it will show "Uploaded" status, not "Published")
+4. Click into that deploy
+5. Click the "Publish deploy" button
+6. Confirm the production URL (scavenger.somanygames.app) now serves the new version
 
-The workflow POSTs to the Netlify build hook, which queues a build from the current HEAD of `main`. Build progress is visible in the Netlify dashboard.
+That's it. Two clicks plus confirmation.
 
-If "Run workflow" is clicked twice before the first deploy completes, the second run queues and waits -- it does not cancel the first.
+## When to publish
 
-## Where to view deploy status
+- After a PR or batch of PRs merges and you want the changes to go live
+- After verifying the changes work in local dev or a deploy preview
+- Never on a Friday afternoon
 
-- **GitHub Actions:** the workflow run logs show the commit SHA, actor, and UTC timestamp of the triggered deploy
-- **Netlify dashboard:** full build logs and deploy history for the production site
+## How to verify Auto Publishing is still locked
 
-## Emergency: how to disable
+The Deploys page header should show an "Auto Publishing Locked" badge. If it shows "Auto publishing is on" instead, click "Lock to stop auto publishing" to re-lock it. Auto publishing being unlocked means every PR merge will publish to production immediately, which burns credits and bypasses the intentional deploy workflow.
 
-If the manual workflow is broken and a deploy is urgently needed, re-enable auto publishing in the Netlify dashboard:
+## In an emergency
 
-`Site settings -> Build & deploy -> Continuous deployment -> Start auto publishing`
+If the deploy-on-demand workflow needs to be bypassed (broken site, urgent fix, etc.):
 
-This bypasses the GitHub workflow entirely and restores the original behavior (deploy on every push to main). Disable again after the emergency is resolved.
+1. Netlify dashboard -> Deploys
+2. Click "Unlock to start auto publishing" - this will publish the most recent build immediately
+3. Once the emergency is resolved, click "Lock to stop auto publishing" again to restore the controlled workflow
+
+## Build hook (legacy)
+
+The repo has a GitHub Actions workflow at .github/workflows/deploy-production.yml that calls a Netlify build hook. With Auto Publishing locked, this workflow triggers a build but does not publish it. The workflow is preserved for future use but is currently redundant - the Netlify UI's "Publish deploy" button is the simpler path.
+
+If you want to remove the redundant workflow, that's a separate cleanup PR. For now it does no harm.
+
+## Cost notes
+
+Even with Auto Publishing locked, every PR merge triggers a build, which consumes Netlify build minutes. To reduce build cost further, the long-term plan is to migrate to Cloudflare Pages (parking lot item in docs/ideas.md), which has more generous free tier limits and clean auto-deploy disable.


### PR DESCRIPTION
## Summary

The deploy-on-demand system works, but the publish step is a manual click in the Netlify UI rather than a GitHub Actions trigger. This documents the actual two-click workflow and notes the GitHub Actions deploy workflow is now redundant.

- Replaces the GitHub Actions trigger instructions with the Netlify UI "Publish deploy" flow
- Documents how Auto Publishing Lock works and how to verify it's active
- Notes the GitHub Actions build hook workflow is preserved but redundant
- Updates README.md Deployment section to match (was "triggered via GitHub Actions")