### PR TITLE
fix: wreck velocity -- apply during drifting, constant 40 px/s through both phases

### DIFF
--- a/src/logic/wreck.test.ts
+++ b/src/logic/wreck.test.ts
@@ -17,6 +17,16 @@ describe('salvageTier', () => {
   });
 });
 
+describe('spawnWreck -- velocity inheritance', () => {
+  it('spawns with vy=25 (50% of Husk descent speed of 50 px/s)', () => {
+    expect(spawnWreck(1, 400, 300, 0).vy).toBe(25);
+  });
+
+  it('spawns with vx=0', () => {
+    expect(spawnWreck(1, 400, 300, 0).vx).toBe(0);
+  });
+});
+
 describe('updateWrecks -- drifting phase', () => {
   it('wreck stays drifting before 4000ms elapses', () => {
     const wreck = spawnWreck(1, 400, 300, 0);
@@ -32,10 +42,17 @@ describe('updateWrecks -- drifting phase', () => {
     expect(result[0].phase).toBe('falling');
   });
 
-  it('wreck position is unchanged during drifting phase', () => {
+  it('wreck moves downward during drifting phase at its spawn vy', () => {
+    // spawnWreck sets vy=25 px/s; after 1000ms (dt=1s) y should increase by 25
     const wreck = spawnWreck(1, 400, 300, 0);
     const result = updateWrecks([wreck], 1000, 1000, null);
-    expect(result[0].y).toBe(300);
+    expect(result[0].y).toBeCloseTo(325, 1);
+  });
+
+  it('wreck moves 0.25px downward in a 10ms frame at vy=25', () => {
+    const wreck = spawnWreck(1, 400, 300, 0); // vy=25
+    const result = updateWrecks([wreck], 10, 10, null);
+    expect(result[0].y).toBeCloseTo(300.25, 3);
   });
 });
 

--- a/src/logic/wreck.test.ts
+++ b/src/logic/wreck.test.ts
@@ -18,8 +18,8 @@ describe('salvageTier', () => {
 });
 
 describe('spawnWreck -- velocity inheritance', () => {
-  it('spawns with vy=25 (50% of Husk descent speed of 50 px/s)', () => {
-    expect(spawnWreck(1, 400, 300, 0).vy).toBe(25);
+  it('spawns with vy=40 (80% of Husk descent speed of 50 px/s)', () => {
+    expect(spawnWreck(1, 400, 300, 0).vy).toBe(40);
   });
 
   it('spawns with vx=0', () => {
@@ -43,16 +43,16 @@ describe('updateWrecks -- drifting phase', () => {
   });
 
   it('wreck moves downward during drifting phase at its spawn vy', () => {
-    // spawnWreck sets vy=25 px/s; after 1000ms (dt=1s) y should increase by 25
+    // spawnWreck sets vy=40 px/s; after 1000ms (dt=1s) y should increase by 40
     const wreck = spawnWreck(1, 400, 300, 0);
     const result = updateWrecks([wreck], 1000, 1000, null);
-    expect(result[0].y).toBeCloseTo(325, 1);
+    expect(result[0].y).toBeCloseTo(340, 1);
   });
 
-  it('wreck moves 0.25px downward in a 10ms frame at vy=25', () => {
-    const wreck = spawnWreck(1, 400, 300, 0); // vy=25
+  it('wreck moves 0.4px downward in a 10ms frame at vy=40', () => {
+    const wreck = spawnWreck(1, 400, 300, 0); // vy=40
     const result = updateWrecks([wreck], 10, 10, null);
-    expect(result[0].y).toBeCloseTo(300.25, 3);
+    expect(result[0].y).toBeCloseTo(300.4, 3);
   });
 });
 
@@ -93,12 +93,10 @@ describe('updateWrecks -- falling phase', () => {
     expect(result[0].scale).toBeCloseTo(0.5, 2);
   });
 
-  it('vy reaches 1.5x spawn vy after 4 seconds of falling', () => {
-    // FALLING_ACCELERATION ramps vy from 25 (1.0x) to 37.5 (1.5x) over 4s
-    // currentTime=7999 keeps scale just above 0 so the wreck survives the frame
-    const wreck: Wreck = { ...spawnWreck(1, 400, 300, 0), phase: 'falling', vy: 25 };
-    const result = updateWrecks([wreck], 4000, 7999, null); // dt=4s, just before scale hits 0
-    expect(result[0].vy).toBeCloseTo(37.5, 1); // 25 + 3.125*4
+  it('vy stays constant during falling (no acceleration)', () => {
+    const wreck: Wreck = { ...spawnWreck(1, 400, 300, 0), phase: 'falling' };
+    const result = updateWrecks([wreck], 1000, 5000, null); // dt=1s
+    expect(result[0].vy).toBe(40);
   });
 
   it('falling wreck moves downward', () => {

--- a/src/logic/wreck.test.ts
+++ b/src/logic/wreck.test.ts
@@ -93,10 +93,12 @@ describe('updateWrecks -- falling phase', () => {
     expect(result[0].scale).toBeCloseTo(0.5, 2);
   });
 
-  it('vy accelerates at 40 px/s² during falling', () => {
+  it('vy reaches 1.5x spawn vy after 4 seconds of falling', () => {
+    // FALLING_ACCELERATION ramps vy from 25 (1.0x) to 37.5 (1.5x) over 4s
+    // currentTime=7999 keeps scale just above 0 so the wreck survives the frame
     const wreck: Wreck = { ...spawnWreck(1, 400, 300, 0), phase: 'falling', vy: 25 };
-    const result = updateWrecks([wreck], 1000, 5000, null); // dt=1s
-    expect(result[0].vy).toBeCloseTo(65, 1); // 25 + 40*1
+    const result = updateWrecks([wreck], 4000, 7999, null); // dt=4s, just before scale hits 0
+    expect(result[0].vy).toBeCloseTo(37.5, 1); // 25 + 3.125*4
   });
 
   it('falling wreck moves downward', () => {

--- a/src/logic/wreck.ts
+++ b/src/logic/wreck.ts
@@ -4,8 +4,7 @@ export const WRECK_HIT_RADIUS = 16;
 
 const DRIFTING_DURATION_MS = 4000;
 const FALLING_DURATION_MS = 4000;
-const FALLING_ACCELERATION = 3.125; // px/s²: ramps vy from 1.0x to 1.5x spawn vy over FALLING_DURATION_MS
-const HUSK_SPAWN_VY = 25; // 50% of Husk descent speed (50px/s)
+const HUSK_SPAWN_VY = 40; // 80% of Husk descent speed (50px/s) -- slight slowdown on death
 
 export interface Wreck {
   id: number;
@@ -58,13 +57,12 @@ export function updateWrecks(
         }
         return { ...w, x, y, driftingAt };
       }
-      // falling phase
+      // falling phase -- constant velocity, scale shrinks to 0 over FALLING_DURATION_MS
       const fallingStartMs = w.driftingAt + DRIFTING_DURATION_MS;
       const fallingElapsedSec = (currentTimeMs - fallingStartMs) / 1000;
       const scale = Math.max(0, 1.0 - fallingElapsedSec / (FALLING_DURATION_MS / 1000));
-      const vy = w.vy + FALLING_ACCELERATION * dt;
       const y = w.y + w.vy * dt;
-      return { ...w, vy, y, scale, alive: scale > 0 };
+      return { ...w, y, scale, alive: scale > 0 };
     })
     .filter((w) => w.alive);
 }

--- a/src/logic/wreck.ts
+++ b/src/logic/wreck.ts
@@ -4,7 +4,7 @@ export const WRECK_HIT_RADIUS = 16;
 
 const DRIFTING_DURATION_MS = 4000;
 const FALLING_DURATION_MS = 4000;
-const FALLING_ACCELERATION = 40; // px/s²
+const FALLING_ACCELERATION = 3.125; // px/s²: ramps vy from 1.0x to 1.5x spawn vy over FALLING_DURATION_MS
 const HUSK_SPAWN_VY = 25; // 50% of Husk descent speed (50px/s)
 
 export interface Wreck {

--- a/src/logic/wreck.ts
+++ b/src/logic/wreck.ts
@@ -51,10 +51,12 @@ export function updateWrecks(
     .map((w): Wreck => {
       if (w.phase === 'drifting') {
         const driftingAt = w.id === tetheredWreckId ? w.driftingAt + deltaMs : w.driftingAt;
+        const x = w.x + w.vx * dt;
+        const y = w.y + w.vy * dt;
         if (currentTimeMs - driftingAt >= DRIFTING_DURATION_MS) {
-          return { ...w, driftingAt, phase: 'falling' };
+          return { ...w, x, y, driftingAt, phase: 'falling' };
         }
-        return { ...w, driftingAt };
+        return { ...w, x, y, driftingAt };
       }
       // falling phase
       const fallingStartMs = w.driftingAt + DRIFTING_DURATION_MS;

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -26,7 +26,7 @@ import { Wreck as WreckEntity } from '../entities/Wreck';
 
 const SLOWMO_FACTOR = 0.2;
 // TODO: vary by game state per tuning.md
-const SCROLL_SPEED = 60;
+const SCROLL_SPEED = 20;
 
 export class GameScene extends Phaser.Scene {
   private inputManager!: InputManager;


### PR DESCRIPTION
## What was broken

Three bugs fixed in this PR:

1. **Wrecks froze in place during drifting.** `updateWrecks` only applied `vx`/`vy` to position in the falling branch. The drifting branch updated `driftingAt` but left x/y unchanged, so wrecks sat motionless for 4 seconds before falling.

2. **Wreck speed was wrong throughout.** The original spawn vy (25 px/s, 50% of Husk) looked too slow, and `FALLING_ACCELERATION = 40 px/s²` drove falling velocity from 25 to 185 px/s (a 7x jump). Even after correcting the acceleration formula, the base speed was visually too slow relative to the Husk.

3. **Background scrolled too fast.** `SCROLL_SPEED = 60` was visually distracting during gameplay.

## What was fixed

- **Drifting phase now applies velocity** -- `x += vx * dt`, `y += vy * dt` each frame.
- **Spawn vy changed from 25 to 40 px/s** -- 80% of Husk's 50 px/s, a slight slowdown on death that reads naturally.
- **Acceleration removed** -- `FALLING_ACCELERATION` is gone. Wreck maintains constant 40 px/s through both drifting and falling phases. The falling phase still shrinks scale to 0 over 4 seconds.
- **Background scroll speed reduced from 60 to 20 px/s.**

## Net behavior

Husk descends at 50 px/s. On death it becomes a wreck moving at 40 px/s. The wreck drifts downward at that speed for 4 seconds (tetherable), then continues at the same speed while shrinking to nothing over 4 more seconds.

## Tests

- Corrected `'wreck position is unchanged during drifting phase'` (was asserting the frozen bug)
- Added: spawn vy=40, 0.4px movement in 10ms frame, constant vy during falling